### PR TITLE
Import packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <div align="center">
     <a href="#"><img src="docs/budi.png" alt="Budi the Orangutan!" width="30%"></a>
-    <h6><em>For When Live Gives You Orngs...</em></h6>
+    <h6><em>For When Life Gives You Orngs...</em></h6>
     <h1>Orng Programming Language</h1>
 </div>
 

--- a/examples/build.orng
+++ b/examples/build.orng
@@ -4,7 +4,6 @@
 // the package being built.
 fn build() -> Package {
     let mut retval = Package::executable(.root="main.orng")
-    let std = Package::find("../std")
-    retval.>requires(std)
+    retval.>requires("std", Package::find("../std"))
     retval
 }

--- a/examples/main.orng
+++ b/examples/main.orng
@@ -1,5 +1,6 @@
 import std
 import externs
+// import core // imported by std, this is what we want to prevent
 
 fn main() -> () {
     externs::println("Hello, ")

--- a/examples/main.orng
+++ b/examples/main.orng
@@ -1,5 +1,7 @@
+import std
 import externs
 
 fn main() -> () {
-    externs::println("Hello, World!")
+    externs::println("Hello, ")
+    std::println("World!")
 }

--- a/src/ast-validate.zig
+++ b/src/ast-validate.zig
@@ -574,7 +574,7 @@ fn validate_AST_internal(
             context.set_entry_point(cfg, ret_type);
             defer context.deinit();
             context.load_module(module);
-            try context.interpret(compiler);
+            try context.run(compiler);
 
             // Extract the retval
             ast.@"comptime".result = context.extract_ast(0, ret_type, compiler.allocator());
@@ -2105,7 +2105,7 @@ fn generate_default_unvalidated(_type: *ast_.AST, span: span_.Span, errors: *err
         .identifier => {
             const expanded_type = _type.expand_type(allocator);
             if (expanded_type == _type) {
-                const primitive_info = primitives_.info_from_name(_type.token().data);
+                const primitive_info = primitives_.info_from_name(_type.token().data).?;
                 if (primitive_info.default_value != null) {
                     return primitive_info.default_value.?;
                 } else {

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -177,7 +177,7 @@ pub const AST = union(enum) {
         _rhs: *AST,
         // _pos: ?usize,
         _symbol: ?*symbol_.Symbol = null,
-        scope: ?*symbol_.Scope = null, // Surrounding scope. Filled in at symbol-tree creation.
+        _scope: ?*symbol_.Scope = null, // Surrounding scope. Filled in at symbol-tree creation.
     },
     function: struct { common: AST_Common, _lhs: *AST, _rhs: *AST },
     trait: struct {
@@ -186,7 +186,7 @@ pub const AST = union(enum) {
         const_decls: std.ArrayList(*AST),
         num_virtual_methods: i64 = 0,
         _symbol: ?*symbol_.Symbol = null, // Filled by symbol-tree pass.
-        scope: ?*symbol_.Scope = null, // Filled by symbol-tree pass.
+        _scope: ?*symbol_.Scope = null, // Filled by symbol-tree pass.
 
         pub fn find_method(self: @This(), name: []const u8) ?*AST {
             for (self.method_decls.items) |decl| {
@@ -204,7 +204,7 @@ pub const AST = union(enum) {
         method_defs: std.ArrayList(*AST),
         const_defs: std.ArrayList(*AST),
         num_virtual_methods: i64 = 0,
-        scope: ?*symbol_.Scope = null, // Scope used for `impl` methods, rooted in `impl`'s scope.
+        _scope: ?*symbol_.Scope = null, // Scope used for `impl` methods, rooted in `impl`'s scope.
         impls_anon_trait: bool = false, // true when this impl implements an anonymous trait
     },
     invoke: struct {
@@ -212,7 +212,7 @@ pub const AST = union(enum) {
         _lhs: *AST,
         _rhs: *AST,
         _args: std.ArrayList(*AST),
-        scope: ?*symbol_.Scope = null, // Surrounding scope. Filled in at symbol-tree creation.
+        _scope: ?*symbol_.Scope = null, // Surrounding scope. Filled in at symbol-tree creation.
         method_decl: ?*AST = null,
     },
     /// A product-type of pointers to the vtable, and to the receiver
@@ -228,7 +228,7 @@ pub const AST = union(enum) {
         _expr: *AST,
         mut: bool,
         impl: ?*AST = null, // The implementation AST, whose vtable should be used
-        scope: ?*symbol_.Scope = null, // Surrounding scope. Filled in when addr-of is converted
+        _scope: ?*symbol_.Scope = null, // Surrounding scope. Filled in when addr-of is converted
     },
     sum_type: struct {
         common: AST_Common,
@@ -316,7 +316,7 @@ pub const AST = union(enum) {
         _expr: *AST,
         mut: bool,
         anytptr: bool = false, // When this is true, the addr_of should output as a void*, and should be cast whenever dereferenced
-        scope: ?*symbol_.Scope = null, // Surrounding scope. Filled in at symbol-tree creation.
+        _scope: ?*symbol_.Scope = null, // Surrounding scope. Filled in at symbol-tree creation.
     },
     slice_of: struct { common: AST_Common, _expr: *AST, kind: Slice_Kind },
     array_of: struct { common: AST_Common, _expr: *AST, len: *AST },
@@ -360,7 +360,7 @@ pub const AST = union(enum) {
     // Control-flow expressions
     @"if": struct {
         common: AST_Common,
-        scope: ?*symbol_.Scope,
+        _scope: ?*symbol_.Scope,
         let: ?*AST,
         condition: *AST,
         _body_block: *AST,
@@ -368,7 +368,7 @@ pub const AST = union(enum) {
     },
     match: struct {
         common: AST_Common,
-        scope: ?*symbol_.Scope,
+        _scope: ?*symbol_.Scope,
         let: ?*AST,
         _expr: *AST,
         _mappings: std.ArrayList(*AST),
@@ -377,11 +377,11 @@ pub const AST = union(enum) {
         common: AST_Common,
         _lhs: *AST,
         _rhs: *AST,
-        scope: ?*symbol_.Scope, // Scope used for `match` mappings, rooted in `match`'s scope. Captures, rhs live in this scope
+        _scope: ?*symbol_.Scope, // Scope used for `match` mappings, rooted in `match`'s scope. Captures, rhs live in this scope
     },
     @"while": struct {
         common: AST_Common,
-        scope: ?*symbol_.Scope,
+        _scope: ?*symbol_.Scope,
         let: ?*AST,
         condition: *AST,
         post: ?*AST,
@@ -390,7 +390,7 @@ pub const AST = union(enum) {
     },
     @"for": struct {
         common: AST_Common,
-        scope: ?*symbol_.Scope,
+        _scope: ?*symbol_.Scope,
         let: ?*AST,
         elem: *AST,
         iterable: *AST,
@@ -399,7 +399,7 @@ pub const AST = union(enum) {
     },
     block: struct {
         common: AST_Common,
-        scope: ?*symbol_.Scope,
+        _scope: ?*symbol_.Scope,
         _statements: std.ArrayList(*AST),
         final: ?*AST, // either `return`, `continue`, or `break`
     },
@@ -899,7 +899,7 @@ pub const AST = union(enum) {
         _token: token_.Token,
         dyn_type: *AST,
         _expr: *AST,
-        scope: *symbol_.Scope,
+        _scope: *symbol_.Scope,
         _mut: bool,
         allocator: std.mem.Allocator,
     ) *AST {
@@ -908,7 +908,7 @@ pub const AST = union(enum) {
             .common = _common,
             .dyn_type = dyn_type,
             ._expr = _expr,
-            .scope = scope,
+            ._scope = _scope,
             .mut = _mut,
         } }, allocator);
     }
@@ -1009,7 +1009,7 @@ pub const AST = union(enum) {
         return AST.box(
             AST{ .@"if" = .{
                 .common = _common,
-                .scope = null,
+                ._scope = null,
                 .let = let,
                 .condition = condition,
                 ._body_block = _body_block,
@@ -1029,7 +1029,7 @@ pub const AST = union(enum) {
         return AST.box(
             AST{ .match = .{
                 .common = AST_Common{ ._token = _token, ._type = null },
-                .scope = null,
+                ._scope = null,
                 .let = let,
                 ._expr = _expr,
                 ._mappings = mappings,
@@ -1044,7 +1044,7 @@ pub const AST = union(enum) {
                 .common = AST_Common{ ._token = _token, ._type = null },
                 ._lhs = _lhs,
                 ._rhs = _rhs,
-                .scope = null,
+                ._scope = null,
             } },
             allocator,
         );
@@ -1062,7 +1062,7 @@ pub const AST = union(enum) {
         return AST.box(
             AST{ .@"while" = .{
                 .common = AST_Common{ ._token = _token, ._type = null },
-                .scope = null,
+                ._scope = null,
                 .let = let,
                 .condition = condition,
                 .post = post,
@@ -1085,7 +1085,7 @@ pub const AST = union(enum) {
         return AST.box(
             AST{ .@"for" = .{
                 .common = AST_Common{ ._token = _token, ._type = null },
-                .scope = null,
+                ._scope = null,
                 .let = let,
                 .elem = elem,
                 .iterable = iterable,
@@ -1108,7 +1108,7 @@ pub const AST = union(enum) {
         return AST.box(
             AST{ .block = .{
                 .common = AST_Common{ ._token = _token, ._type = null },
-                .scope = null,
+                ._scope = null,
                 ._statements = statements,
                 .final = final,
             } },
@@ -1677,6 +1677,14 @@ pub const AST = union(enum) {
 
     pub fn set_symbol(self: *AST, val: ?*symbol_.Symbol) void {
         set_field(self, "_symbol", val);
+    }
+
+    pub fn scope(self: AST) ?*symbol_.Scope {
+        return get_struct_field(self, "_scope");
+    }
+
+    pub fn set_scope(self: *AST, val: ?*symbol_.Scope) void {
+        set_field(self, "_scope", val);
     }
 
     pub fn lhs(self: AST) *AST {

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -1,3 +1,5 @@
+// TODO: Can this file be split up?? At ALL?
+
 const std = @import("std");
 const errs_ = @import("errors.zig");
 const module_ = @import("module.zig");
@@ -293,7 +295,6 @@ pub const AST = union(enum) {
         }
 
         /// Retrieves the offset in bytes given a field's index
-        /// TODO: Add a version that works with field names!!
         pub fn get_offset(self: *@This(), field: usize, allocator: std.mem.Allocator) i64 {
             var offset: i64 = 0;
             for (0..field) |i| {

--- a/src/builtin.zig
+++ b/src/builtin.zig
@@ -21,16 +21,23 @@ pub fn module_path() []const u8 {}
 
 /// Implements the Package::find method at build-time. Takes in a string representing the name of
 /// the package in the Orng cache, and returns an AST representing the package.
-pub fn package_find(compiler: *compiler_.Context, interpreter: *interpreter_.Context, current_module_path: []const u8, package_path: []const u8) Error!i64 {
+pub fn package_find(compiler: *compiler_.Context, interpreter: *interpreter_.Context, current_module_path: []const u8, package_path: []const u8) Error!struct { package_adrs: i64, package_dirname: []const u8 } {
     // Construct the path to the package's `build.orng` file
     const current_package = std.fs.path.dirname(current_module_path).?;
-    const package_build_paths = [_][]const u8{ current_package, package_path, "build.orng" };
-    const package_build_dir = std.fs.path.join(compiler.allocator(), &package_build_paths) catch unreachable;
+    const required_package_paths = [_][]const u8{ current_package, package_path };
+    const required_package_path = std.fs.path.join(compiler.allocator(), &required_package_paths) catch unreachable;
+
+    const package_buffer = compiler.allocator().alloc(u8, std.fs.MAX_PATH_BYTES) catch unreachable;
+    const package_absolute_path = std.fs.cwd().realpath(required_package_path, package_buffer) catch return error.CompileError;
+
+    const package_build_paths = [_][]const u8{ package_absolute_path, "build.orng" };
+    const package_build_path = std.fs.path.join(compiler.allocator(), &package_build_paths) catch unreachable;
+
     const path_buffer = compiler.allocator().alloc(u8, std.fs.MAX_PATH_BYTES) catch unreachable;
-    const package_build_file = std.fs.cwd().realpath(package_build_dir, path_buffer) catch return error.CompileError;
+    const package_build_absolute_path = std.fs.cwd().realpath(package_build_path, path_buffer) catch return error.CompileError;
 
     // Compile the package's `build.orng` file
-    const build_cfg = try compiler.compile_build_file(package_build_file);
+    const build_cfg = try compiler.compile_build_file(package_build_absolute_path);
     interpreter.load_module(build_cfg.symbol.scope.module.?);
 
     // Allocate space for the package to be placed
@@ -38,8 +45,9 @@ pub fn package_find(compiler: *compiler_.Context, interpreter: *interpreter_.Con
     const adrs: i64 = @intCast(try interpreter.alloc(@intCast(package_len), 8));
     const retval_place = lval_.L_Value.create_raw_address(adrs, compiler.allocator());
 
-    // Call the `build()` fn
+    // Jump to the `build()` fn
     try interpreter.call(build_cfg.symbol, retval_place, std.ArrayList(*lval_.L_Value).init(compiler.allocator()));
+    try interpreter.run(compiler);
 
-    return adrs;
+    return .{ .package_adrs = adrs, .package_dirname = package_absolute_path };
 }

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -927,7 +927,7 @@ fn output_operator(ir: *ir_.IR, writer: Writer) CodeGen_Error!void {
 
 /// Prints out the vtable name given an impl AST
 fn output_vtable_impl(
-    impl: *ast_.AST, // TODO: Accept uid
+    impl: *ast_.AST,
     writer: Writer,
 ) CodeGen_Error!void {
     try writer.print("_{}_$vtable", .{impl.scope().?.uid});

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -438,7 +438,7 @@ fn output_type(_type: *ast_.AST, writer: Writer) CodeGen_Error!void {
         .identifier => if (_type.common()._expanded_type != null and _type.common()._expanded_type.? != _type) {
             try output_type(_type.common()._expanded_type.?, writer);
         } else {
-            try writer.print("{s}", .{primitives_.info_from_name(_type.token().data).c_name}).?;
+            try writer.print("{s}", .{primitives_.info_from_name(_type.token().data).?.c_name});
         },
         .addr_of => {
             try output_type(_type.expr(), writer);

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -378,7 +378,7 @@ fn output_main_function(
     var specifier: []const u8 = undefined;
     switch (codomain.*) {
         .identifier => {
-            const info = primitives_.info_from_name(codomain.token().data);
+            const info = primitives_.info_from_name(codomain.token().data).?;
             specifier = switch (info.type_kind) {
                 .boolean, .signed_integer => "d",
                 .unsigned_integer => "u",
@@ -438,7 +438,7 @@ fn output_type(_type: *ast_.AST, writer: Writer) CodeGen_Error!void {
         .identifier => if (_type.common()._expanded_type != null and _type.common()._expanded_type.? != _type) {
             try output_type(_type.common()._expanded_type.?, writer);
         } else {
-            try writer.print("{s}", .{primitives_.info_from_name(_type.token().data).c_name});
+            try writer.print("{s}", .{primitives_.info_from_name(_type.token().data).c_name}).?;
         },
         .addr_of => {
             try output_type(_type.expr(), writer);

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -276,7 +276,7 @@ fn output_impls(
             continue;
         }
         const trait = impl.impl.trait.?;
-        try writer.print("struct vtable_{s} _{}_$vtable = {{\n", .{ trait.symbol().?.name, impl.impl.scope.?.uid });
+        try writer.print("struct vtable_{s} _{}_$vtable = {{\n", .{ trait.symbol().?.name, impl.scope().?.uid });
         for (impl.impl.method_defs.items) |decl| {
             if (!decl.method_decl.is_virtual) {
                 continue;
@@ -930,5 +930,5 @@ fn output_vtable_impl(
     impl: *ast_.AST, // TODO: Accept uid
     writer: Writer,
 ) CodeGen_Error!void {
-    try writer.print("_{}_$vtable", .{impl.impl.scope.?.uid});
+    try writer.print("_{}_$vtable", .{impl.scope().?.uid});
 }

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -41,7 +41,7 @@ pub fn generate(module: *module_.Module, writer: Writer) CodeGen_Error!void {
     try forall_functions(&module.cfgs, "/* Function forward definitions */", writer, output_forward_function);
     try output_impls(&module.impls, writer);
     try forall_functions(&module.cfgs, "\n/* Function definitions */", writer, output_function_definition);
-    try output_main_function(module.entry, writer);
+    try output_main_function(module.entry.?, writer);
 }
 
 /// Outputs forward declarations for typedefs based on the provided `Type_Set`.

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -68,7 +68,6 @@ pub const Context = struct {
         }
 
         // Open the file
-        std.debug.print("path: {s}\n", .{absolute_path});
         var file = std.fs.openFileAbsolute(absolute_path, .{}) catch |err| switch (err) {
             error.FileNotFound => return error.FileNotFound,
             else => return error.CompileError,

--- a/src/decorate.zig
+++ b/src/decorate.zig
@@ -4,261 +4,84 @@ const std = @import("std");
 const ast_ = @import("ast.zig");
 const errs_ = @import("errors.zig");
 const symbol_ = @import("symbol.zig");
+const walk_ = @import("walker.zig");
 
-const Decorate_Error = error{CompileError};
-
-/// Recursively decorates the identifiers in the given ASTs with the symbols they refer to.
-///
-/// ## Parameters:
-/// - `asts`: List of ASTs to recursively decorate
-/// - `scope`: Shared scope of all the ASTs
-/// - `errors`: Error manager
-/// - `allocator`: Allocator to use
-///
-/// ## Errors:
-/// Errors out if symbols cannot be looked up. Error messages are added to the error manager.
-pub fn decorate_identifiers_from_list(
-    asts: std.ArrayList(*ast_.AST),
+pub const Decorate_Identifiers = struct {
     scope: *symbol_.Scope,
     errors: *errs_.Errors,
     allocator: std.mem.Allocator,
-) Decorate_Error!void {
-    for (asts.items) |ast| {
-        try decorate_identifiers(ast, scope, errors, allocator);
+
+    const Self = @This();
+
+    pub fn new(scope: *symbol_.Scope, errors: *errs_.Errors, allocator: std.mem.Allocator) Self {
+        return Self{
+            .scope = scope,
+            .errors = errors,
+            .allocator = allocator,
+        };
     }
-}
 
-// TODO:
-//
-// // A struct to contain a generic pass
-// fn Pass(comptime ctx: type) type {
-//     return struct {
-//         run: *const fn(ast_.AST, ctx) Pass_Error!void
-//     };
-// }
-//
-// // A function that walks over an AST, applying pass's function to each one
-// fn walk_ast(ast: *ast_.AST, context: anytype, pass: comptime{Pass(@TypeOf(context))}) Pass_Error!void {
-//     try pass.run(ast, context);
-//     switch (ast.*) {
-//         .add, sub, mul, div, .mod => {
-//             try walk_ast(ast.lhs(), context);
-//             try walk_ast(ast.rhs(), context);
-//         }
-//     }
-// }
-//
-// const Decorate_Context = struct {scope: *symbol_.Scope, errors: *errs_.Errors, allocator: std.mem.Allocator};
-// fn decorate(ast: *ast_.AST, ctx: Decorate_Context) Pass_Error!void {
-//     if (ast.* == .identifier) {
-//         // decorate the identifier
-//     } // That's it!
-// }
+    pub fn prefix(self: Self, ast: *ast_.AST) walk_.Error!Self {
+        switch (ast.*) {
+            else => return self,
 
-/// Recursively decorates the identifiers in the given AST with the symbols they refer to.
-///
-/// ## Parameters:
-/// - `ast`: AST to recursively decorate with symbols
-/// - `scope`: Scope of the AST
-/// - `errors`: Error manager
-/// - `allocator`: Allocator to use
-///
-/// ## Errors:
-/// Errors out if symbols cannot be looked up. Error messages are added to the error manager.
-pub fn decorate_identifiers(
-    maybe_ast: ?*ast_.AST,
-    scope: *symbol_.Scope,
-    errors: *errs_.Errors,
-    allocator: std.mem.Allocator,
-) Decorate_Error!void {
-    if (maybe_ast == null) {
-        return;
+            .identifier => {
+                const res = self.scope.lookup(ast.token().data, false);
+                switch (res) {
+                    // Found the symbol, decorate the identifier AST with it
+                    .found => ast.set_symbol(res.found),
+
+                    // Couldn't find the symbol
+                    .not_found => {
+                        self.errors.add_error(errs_.Error{ .undeclared_identifier = .{ .identifier = ast.token(), .expected = null } });
+                        return error.CompileError;
+                    },
+
+                    // Found the symbol, but must cross a comptime-boundary to access it, and it is not const
+                    .found_but_rt => {
+                        self.errors.add_error(errs_.Error{ .comptime_access_runtime = .{ .identifier = ast.token() } });
+                        return error.CompileError;
+                    },
+
+                    // Found the symbol, but must cross an inner-function boundary to access it, and it is not const
+                    .found_but_fn => {
+                        self.errors.add_error(errs_.Error{ .inner_fn_access_runtime = .{ .identifier = ast.token() } });
+                        return error.CompileError;
+                    },
+                }
+                if (!ast.symbol().?.defined) {
+                    self.errors.add_error(errs_.Error{ .use_before_def = .{ .identifier = ast.token() } });
+                    return error.CompileError;
+                }
+
+                return self;
+            },
+
+            .@"if", .match, .mapping, .@"while", .@"for", .block, .impl, .trait => {
+                var new_context = self;
+                new_context.scope = ast.scope().?;
+                return new_context;
+            },
+
+            .fn_decl => {
+                var new_context = self;
+                new_context.scope = ast.symbol().?.scope;
+                return new_context;
+            },
+        }
     }
-    const ast = maybe_ast.?;
-    switch (ast.*) {
-        .anyptr_type,
-        .unit_type,
-        .unit_value,
-        .int,
-        .char,
-        .float,
-        .string,
-        .field,
-        .@"unreachable",
-        .true,
-        .false,
-        .@"break",
-        .@"continue",
-        .poison,
-        .pattern_symbol,
-        .domain_of,
-        .receiver,
-        .template,
-        => {},
 
-        .identifier => {
-            const res = scope.lookup(ast.token().data, false);
-            switch (res) {
-                // Found the symbol, decorate the identifier AST with it
-                .found => ast.set_symbol(res.found),
+    pub fn postfix(self: Self, ast: *ast_.AST) walk_.Error!void {
+        switch (ast.*) {
+            else => {},
 
-                // Couldn't find the symbol
-                .not_found => {
-                    errors.add_error(errs_.Error{ .undeclared_identifier = .{ .identifier = ast.token(), .expected = null } });
-                    return error.CompileError;
-                },
-
-                // Found the symbol, but must cross a comptime-boundary to access it, and it is not const
-                .found_but_rt => {
-                    errors.add_error(errs_.Error{ .comptime_access_runtime = .{ .identifier = ast.token() } });
-                    return error.CompileError;
-                },
-
-                // Found the symbol, but must cross an inner-function boundary to access it, and it is not const
-                .found_but_fn => {
-                    errors.add_error(errs_.Error{ .inner_fn_access_runtime = .{ .identifier = ast.token() } });
-                    return error.CompileError;
-                },
-            }
-            if (!ast.symbol().?.defined) {
-                errors.add_error(errs_.Error{ .use_before_def = .{ .identifier = ast.token() } });
-                return error.CompileError;
-            }
-        },
-
-        .type_of,
-        .default,
-        .size_of,
-        .not,
-        .negate,
-        .dereference,
-        .@"try",
-        .@"comptime",
-        .addr_of,
-        .slice_of,
-        .dyn_type,
-        .dyn_value,
-        => try decorate_identifiers(ast.expr(), scope, errors, allocator),
-
-        .assign,
-        .@"or",
-        .@"and",
-        .add,
-        .sub,
-        .mult,
-        .div,
-        .mod,
-        .equal,
-        .not_equal,
-        .greater,
-        .lesser,
-        .greater_equal,
-        .lesser_equal,
-        .@"catch",
-        .@"orelse",
-        .index,
-        .select,
-        .access,
-        .function,
-        .@"union",
-        => {
-            try decorate_identifiers(ast.lhs(), scope, errors, allocator);
-            try decorate_identifiers(ast.rhs(), scope, errors, allocator);
-        },
-        .invoke => {
-            try decorate_identifiers(ast.lhs(), scope, errors, allocator);
-            try decorate_identifiers(ast.rhs(), scope, errors, allocator);
-            try decorate_identifiers_from_list(ast.children().*, scope, errors, allocator);
-        },
-        .call => {
-            try decorate_identifiers(ast.lhs(), scope, errors, allocator);
-            try decorate_identifiers_from_list(ast.children().*, scope, errors, allocator);
-        },
-        .sum_type, .product => try decorate_identifiers_from_list(ast.children().*, scope, errors, allocator),
-        .sum_value => {
-            try decorate_identifiers(ast.sum_value.init, scope, errors, allocator);
-            try decorate_identifiers(ast.sum_value.base, scope, errors, allocator);
-        },
-        .array_of => {
-            try decorate_identifiers(ast.expr(), scope, errors, allocator);
-            try decorate_identifiers(ast.array_of.len, scope, errors, allocator);
-        },
-        .sub_slice => {
-            try decorate_identifiers(ast.sub_slice.super, scope, errors, allocator);
-            try decorate_identifiers(ast.sub_slice.lower, scope, errors, allocator);
-            try decorate_identifiers(ast.sub_slice.upper, scope, errors, allocator);
-        },
-        .annotation => {
-            try decorate_identifiers(ast.annotation.type, scope, errors, allocator);
-            try decorate_identifiers(ast.annotation.predicate, scope, errors, allocator);
-            try decorate_identifiers(ast.annotation.init, scope, errors, allocator);
-        },
-        .@"if" => {
-            try decorate_identifiers(ast.@"if".let, scope, errors, allocator);
-            try decorate_identifiers(ast.@"if".condition, ast.@"if".scope.?, errors, allocator);
-            try decorate_identifiers(ast.body_block(), ast.@"if".scope.?, errors, allocator);
-            try decorate_identifiers(ast.else_block(), ast.@"if".scope.?, errors, allocator);
-        },
-        .match => {
-            try decorate_identifiers(ast.match.let, scope, errors, allocator);
-            try decorate_identifiers(ast.expr(), ast.match.scope.?, errors, allocator);
-            try decorate_identifiers_from_list(ast.children().*, ast.match.scope.?, errors, allocator);
-        },
-        .mapping => {
-            try decorate_identifiers(ast.lhs(), scope, errors, allocator);
-            try decorate_identifiers(ast.rhs(), ast.mapping.scope orelse scope, errors, allocator);
-        },
-        .@"while" => {
-            try decorate_identifiers(ast.@"while".let, scope, errors, allocator);
-            try decorate_identifiers(ast.@"while".condition, ast.@"while".scope.?, errors, allocator);
-            try decorate_identifiers(ast.@"while".post, ast.@"while".scope.?, errors, allocator);
-            try decorate_identifiers(ast.body_block(), ast.@"while".scope.?, errors, allocator);
-            try decorate_identifiers(ast.else_block(), ast.@"while".scope.?, errors, allocator);
-        },
-        .@"for" => {
-            try decorate_identifiers(ast.@"for".let, scope, errors, allocator);
-            try decorate_identifiers(ast.@"for".elem, ast.@"for".scope.?, errors, allocator);
-            try decorate_identifiers(ast.@"for".iterable, ast.@"for".scope.?, errors, allocator);
-            try decorate_identifiers(ast.body_block(), ast.@"for".scope.?, errors, allocator);
-            try decorate_identifiers(ast.else_block(), ast.@"for".scope.?, errors, allocator);
-        },
-        .block => {
-            // std.debug.print("{}\n", .{ast.token().span});
-            try decorate_identifiers_from_list(ast.children().*, ast.block.scope.?, errors, allocator);
-            if (ast.block.final) |final| {
-                try decorate_identifiers(final, ast.block.scope.?, errors, allocator);
-            }
-        },
-        .@"return" => try decorate_identifiers(ast.@"return"._ret_expr, scope, errors, allocator),
-        .decl => {
-            try decorate_identifiers(ast.decl.type, scope, errors, allocator);
-            try decorate_identifiers(ast.decl.init, scope, errors, allocator);
-            for (ast.decl.symbols.items) |symbol| {
-                symbol.defined = true;
-            }
-        },
-        .fn_decl => {
-            try decorate_identifiers(ast.fn_decl.init, ast.symbol().?.scope, errors, allocator);
-            try decorate_identifiers_from_list(ast.children().*, ast.symbol().?.scope, errors, allocator);
-            try decorate_identifiers(ast.fn_decl.ret_type, ast.symbol().?.scope, errors, allocator);
-        },
-        .trait => {
-            try decorate_identifiers_from_list(ast.trait.method_decls, ast.trait.scope.?, errors, allocator);
-            try decorate_identifiers_from_list(ast.trait.const_decls, ast.trait.scope.?, errors, allocator);
-            scope.traits.append(ast) catch unreachable;
-        },
-        .impl => {
-            try decorate_identifiers(ast.impl._type, scope, errors, allocator);
-            try decorate_identifiers(ast.impl.trait, ast.impl.scope.?, errors, allocator);
-            try decorate_identifiers_from_list(ast.impl.method_defs, ast.impl.scope.?, errors, allocator);
-            try decorate_identifiers_from_list(ast.impl.const_defs, ast.impl.scope.?, errors, allocator);
-            scope.impls.append(ast) catch unreachable;
-        },
-        .method_decl => {
-            try decorate_identifiers(ast.method_decl.init, scope, errors, allocator);
-            try decorate_identifiers_from_list(ast.children().*, scope, errors, allocator);
-            try decorate_identifiers(ast.method_decl.ret_type, scope, errors, allocator);
-        },
-        .@"defer", .@"errdefer" => try decorate_identifiers(ast.statement(), scope, errors, allocator),
+            .decl => {
+                for (ast.decl.symbols.items) |symbol| {
+                    symbol.defined = true;
+                }
+            },
+            .trait => self.scope.traits.append(ast) catch unreachable,
+            .impl => self.scope.impls.append(ast) catch unreachable,
+        }
     }
-}
+};

--- a/src/decorate.zig
+++ b/src/decorate.zig
@@ -6,82 +6,80 @@ const errs_ = @import("errors.zig");
 const symbol_ = @import("symbol.zig");
 const walk_ = @import("walker.zig");
 
-pub const Decorate_Identifiers = struct {
-    scope: *symbol_.Scope,
-    errors: *errs_.Errors,
-    allocator: std.mem.Allocator,
+scope: *symbol_.Scope,
+errors: *errs_.Errors,
+allocator: std.mem.Allocator,
 
-    const Self = @This();
+const Self = @This();
 
-    pub fn new(scope: *symbol_.Scope, errors: *errs_.Errors, allocator: std.mem.Allocator) Self {
-        return Self{
-            .scope = scope,
-            .errors = errors,
-            .allocator = allocator,
-        };
-    }
+pub fn new(scope: *symbol_.Scope, errors: *errs_.Errors, allocator: std.mem.Allocator) Self {
+    return Self{
+        .scope = scope,
+        .errors = errors,
+        .allocator = allocator,
+    };
+}
 
-    pub fn prefix(self: Self, ast: *ast_.AST) walk_.Error!Self {
-        switch (ast.*) {
-            else => return self,
+pub fn prefix(self: Self, ast: *ast_.AST) walk_.Error!Self {
+    switch (ast.*) {
+        else => return self,
 
-            .identifier => {
-                const res = self.scope.lookup(ast.token().data, false);
-                switch (res) {
-                    // Found the symbol, decorate the identifier AST with it
-                    .found => ast.set_symbol(res.found),
+        .identifier => {
+            const res = self.scope.lookup(ast.token().data, false);
+            switch (res) {
+                // Found the symbol, decorate the identifier AST with it
+                .found => ast.set_symbol(res.found),
 
-                    // Couldn't find the symbol
-                    .not_found => {
-                        self.errors.add_error(errs_.Error{ .undeclared_identifier = .{ .identifier = ast.token(), .expected = null } });
-                        return error.CompileError;
-                    },
-
-                    // Found the symbol, but must cross a comptime-boundary to access it, and it is not const
-                    .found_but_rt => {
-                        self.errors.add_error(errs_.Error{ .comptime_access_runtime = .{ .identifier = ast.token() } });
-                        return error.CompileError;
-                    },
-
-                    // Found the symbol, but must cross an inner-function boundary to access it, and it is not const
-                    .found_but_fn => {
-                        self.errors.add_error(errs_.Error{ .inner_fn_access_runtime = .{ .identifier = ast.token() } });
-                        return error.CompileError;
-                    },
-                }
-                if (!ast.symbol().?.defined) {
-                    self.errors.add_error(errs_.Error{ .use_before_def = .{ .identifier = ast.token() } });
+                // Couldn't find the symbol
+                .not_found => {
+                    self.errors.add_error(errs_.Error{ .undeclared_identifier = .{ .identifier = ast.token(), .expected = null } });
                     return error.CompileError;
-                }
+                },
 
-                return self;
-            },
+                // Found the symbol, but must cross a comptime-boundary to access it, and it is not const
+                .found_but_rt => {
+                    self.errors.add_error(errs_.Error{ .comptime_access_runtime = .{ .identifier = ast.token() } });
+                    return error.CompileError;
+                },
 
-            .@"if", .match, .mapping, .@"while", .@"for", .block, .impl, .trait => {
-                var new_context = self;
-                new_context.scope = ast.scope().?;
-                return new_context;
-            },
+                // Found the symbol, but must cross an inner-function boundary to access it, and it is not const
+                .found_but_fn => {
+                    self.errors.add_error(errs_.Error{ .inner_fn_access_runtime = .{ .identifier = ast.token() } });
+                    return error.CompileError;
+                },
+            }
+            if (!ast.symbol().?.defined) {
+                self.errors.add_error(errs_.Error{ .use_before_def = .{ .identifier = ast.token() } });
+                return error.CompileError;
+            }
 
-            .fn_decl => {
-                var new_context = self;
-                new_context.scope = ast.symbol().?.scope;
-                return new_context;
-            },
-        }
+            return self;
+        },
+
+        .@"if", .match, .mapping, .@"while", .@"for", .block, .impl, .trait => {
+            var new_context = self;
+            new_context.scope = ast.scope().?;
+            return new_context;
+        },
+
+        .fn_decl => {
+            var new_context = self;
+            new_context.scope = ast.symbol().?.scope;
+            return new_context;
+        },
     }
+}
 
-    pub fn postfix(self: Self, ast: *ast_.AST) walk_.Error!void {
-        switch (ast.*) {
-            else => {},
+pub fn postfix(self: Self, ast: *ast_.AST) walk_.Error!void {
+    switch (ast.*) {
+        else => {},
 
-            .decl => {
-                for (ast.decl.symbols.items) |symbol| {
-                    symbol.defined = true;
-                }
-            },
-            .trait => self.scope.traits.append(ast) catch unreachable,
-            .impl => self.scope.impls.append(ast) catch unreachable,
-        }
+        .decl => {
+            for (ast.decl.symbols.items) |symbol| {
+                symbol.defined = true;
+            }
+        },
+        .trait => self.scope.traits.append(ast) catch unreachable,
+        .impl => self.scope.impls.append(ast) catch unreachable,
     }
-};
+}

--- a/src/decorate.zig
+++ b/src/decorate.zig
@@ -20,7 +20,7 @@ pub fn new(scope: *symbol_.Scope, errors: *errs_.Errors, allocator: std.mem.Allo
     };
 }
 
-pub fn prefix(self: Self, ast: *ast_.AST) walk_.Error!Self {
+pub fn prefix(self: Self, ast: *ast_.AST) walk_.Error!?Self {
     switch (ast.*) {
         else => return self,
 

--- a/src/decorate.zig
+++ b/src/decorate.zig
@@ -31,22 +31,25 @@ pub fn decorate_identifiers_from_list(
 // TODO:
 //
 // // A struct to contain a generic pass
-// const Pass = struct {
-//     run: *const fn(ast_.AST, scope: *symbol_.Scope, errors: *errs_.Errors, allocator: std.mem.Allocator) Pass_Error!void
-// };
+// fn Pass(comptime ctx: type) type {
+//     return struct {
+//         run: *const fn(ast_.AST, ctx) Pass_Error!void
+//     };
+// }
 //
 // // A function that walks over an AST, applying pass's function to each one
-// fn walk_ast(ast: *ast_.AST, scope: *symbol_.Scope, errors: *errs_.Errors, allocator: std.mem.Allocator, pass: Pass) Pass_Error!void {
-//     try pass.run(ast, scope, errors, allocator);
+// fn walk_ast(ast: *ast_.AST, context: anytype, pass: comptime{Pass(@TypeOf(context))}) Pass_Error!void {
+//     try pass.run(ast, context);
 //     switch (ast.*) {
 //         .add, sub, mul, div, .mod => {
-//             try walk_ast(ast.lhs(), scope, errors, allocator);
-//             try walk_ast(ast.rhs(), scope, errors, allocator);
+//             try walk_ast(ast.lhs(), context);
+//             try walk_ast(ast.rhs(), context);
 //         }
 //     }
 // }
 //
-// fn decorate(ast: *ast_.AST, scope: *symbol_.Scope, errors: *errs_.Errors, allocator: std.mem.Allocator) Pass_Error!void {
+// const Decorate_Context = struct {scope: *symbol_.Scope, errors: *errs_.Errors, allocator: std.mem.Allocator};
+// fn decorate(ast: *ast_.AST, ctx: Decorate_Context) Pass_Error!void {
 //     if (ast.* == .identifier) {
 //         // decorate the identifier
 //     } // That's it!

--- a/src/errors.zig
+++ b/src/errors.zig
@@ -593,7 +593,7 @@ pub const Errors = struct {
 
     pub fn add_error(self: *Errors, err: Error) void {
         self.errors_list.append(err) catch unreachable;
-        err.peek_error(); // uncomment if you want to see where errors come from
+        // err.peek_error(); // uncomment if you want to see where errors come from
     }
 
     pub fn print_errors(self: *Errors) void {

--- a/src/errors.zig
+++ b/src/errors.zig
@@ -593,7 +593,7 @@ pub const Errors = struct {
 
     pub fn add_error(self: *Errors, err: Error) void {
         self.errors_list.append(err) catch unreachable;
-        // err.peek_error(); // uncomment if you want to see where errors come from
+        err.peek_error(); // uncomment if you want to see where errors come from
     }
 
     pub fn print_errors(self: *Errors) void {

--- a/src/expand.zig
+++ b/src/expand.zig
@@ -19,7 +19,8 @@ pub fn new(errors: *errs_.Errors, allocator: std.mem.Allocator) Self {
     };
 }
 
-pub fn prefix(self: Self, ast: *ast_.AST) walk_.Error!Self {
+/// Expand ASTs before descending to further children
+pub fn prefix(self: Self, ast: *ast_.AST) walk_.Error!?Self {
     switch (ast.*) {
         else => {},
 

--- a/src/expand.zig
+++ b/src/expand.zig
@@ -5,107 +5,40 @@ const ast_ = @import("ast.zig");
 const errs_ = @import("errors.zig");
 const primitives_ = @import("primitives.zig");
 const token_ = @import("token.zig");
+const walk_ = @import("walker.zig");
 
-const Expand_Error = error{CompileError};
+errors: *errs_.Errors,
+allocator: std.mem.Allocator,
 
-pub fn expand_from_list(
-    asts: std.ArrayList(*ast_.AST),
-    errors: *errs_.Errors,
-    allocator: std.mem.Allocator,
-) Expand_Error!void {
-    for (asts.items) |ast| {
-        try expand(ast, errors, allocator);
-    }
+const Self = @This();
+
+pub fn new(errors: *errs_.Errors, allocator: std.mem.Allocator) Self {
+    return Self{
+        .errors = errors,
+        .allocator = allocator,
+    };
 }
 
-fn expand(maybe_ast: ?*ast_.AST, errors: *errs_.Errors, allocator: std.mem.Allocator) Expand_Error!void {
-    if (maybe_ast == null) {
-        return;
-    }
-    const ast = maybe_ast.?;
+pub fn prefix(self: Self, ast: *ast_.AST) walk_.Error!Self {
     switch (ast.*) {
-        .anyptr_type,
-        .unit_type,
-        .unit_value,
-        .int,
-        .char,
-        .float,
-        .string,
-        .field,
-        .identifier,
-        .@"unreachable",
-        .true,
-        .false,
-        .@"break",
-        .@"continue",
-        .poison,
-        .pattern_symbol,
-        .domain_of,
-        .receiver,
-        => {},
+        else => {},
 
-        .type_of,
-        .default,
-        .size_of,
-        .not,
-        .negate,
-        .dereference,
-        .@"try",
-        .@"comptime",
-        .addr_of,
-        .slice_of,
-        .dyn_type,
-        .dyn_value,
-        => try expand(ast.expr(), errors, allocator),
-
-        .template => unreachable,
-
-        .assign,
-        .@"or",
-        .@"and",
-        .add,
-        .sub,
-        .mult,
-        .div,
-        .mod,
-        .equal,
-        .not_equal,
-        .greater,
-        .lesser,
-        .greater_equal,
-        .lesser_equal,
-        .@"catch",
-        .@"orelse",
-        .index,
-        .select,
-        .access,
-        .function,
-        .invoke,
-        .@"union",
-        => {
-            try expand(ast.lhs(), errors, allocator);
-            try expand(ast.rhs(), errors, allocator);
-        },
-        .call => {
-            try expand(ast.lhs(), errors, allocator);
-            try expand_from_list(ast.children().*, errors, allocator);
-        },
         .sum_type => {
             var changed = false;
-            var new_terms = std.ArrayList(*ast_.AST).init(allocator);
-            var idents_seen = std.StringArrayHashMap(*ast_.AST).init(allocator);
+            var new_terms = std.ArrayList(*ast_.AST).init(self.allocator);
+            var idents_seen = std.StringArrayHashMap(*ast_.AST).init(self.allocator);
             defer idents_seen.deinit();
             errdefer new_terms.deinit();
 
             // Make sure identifiers aren't repeated
             for (ast.children().items) |term| {
                 changed = changed or term.* == .identifier;
-                var annotation: *ast_.AST = try annot_from_ast(term, errors, allocator);
+                var annotation: *ast_.AST = try annot_from_ast(term, self.errors, self.allocator);
                 new_terms.append(annotation) catch unreachable;
                 const name = annotation.annotation.pattern.token().data;
                 const res = idents_seen.fetchPut(name, annotation) catch unreachable;
                 if (res) |_res| {
-                    errors.add_error(errs_.Error{
+                    self.errors.add_error(errs_.Error{
                         .duplicate = .{ .span = term.token().span, .identifier = name, .first = _res.value.token().span },
                     });
                     return error.CompileError;
@@ -117,108 +50,28 @@ fn expand(maybe_ast: ?*ast_.AST, errors: *errs_.Errors, allocator: std.mem.Alloc
             } else {
                 new_terms.deinit();
             }
+        },
 
-            try expand_from_list(ast.children().*, errors, allocator);
-        },
-        .sum_value => {
-            try expand(ast.sum_value.init, errors, allocator);
-            try expand(ast.sum_value.base, errors, allocator);
-        },
-        .product => try expand_from_list(ast.children().*, errors, allocator),
-        .array_of => {
-            try expand(ast.expr(), errors, allocator);
-            try expand(ast.array_of.len, errors, allocator);
-        },
         .sub_slice => {
             if (ast.sub_slice.lower == null) {
-                ast.sub_slice.lower = ast_.AST.create_int(ast.token(), 0, allocator);
+                ast.sub_slice.lower = ast_.AST.create_int(ast.token(), 0, self.allocator);
             }
             if (ast.sub_slice.upper == null) {
-                const length = ast_.AST.create_field(token_.Token.init("length", null, "", "", 0, 0), allocator);
+                const length = ast_.AST.create_field(token_.Token.init("length", null, "", "", 0, 0), self.allocator);
                 ast.sub_slice.upper = ast_.AST.create_select(
                     ast.token(),
                     ast.sub_slice.super,
                     length,
-                    allocator,
+                    self.allocator,
                 );
             }
-
-            try expand(ast.sub_slice.super, errors, allocator);
-            try expand(ast.sub_slice.lower, errors, allocator);
-            try expand(ast.sub_slice.upper, errors, allocator);
         },
-        .annotation => {
-            try expand(ast.annotation.type, errors, allocator);
-            try expand(ast.annotation.predicate, errors, allocator);
-            try expand(ast.annotation.init, errors, allocator);
-        },
-
-        .@"if" => { // TODO: Re-write `if let; cond b1 else b2` to be `{let; if cond b1 orelse b2}`
-            try expand(ast.@"if".let, errors, allocator);
-            try expand(ast.@"if".condition, errors, allocator);
-            try expand(ast.body_block(), errors, allocator);
-            try expand(ast.else_block(), errors, allocator);
-        },
-        .match => {
-            try expand(ast.match.let, errors, allocator);
-            try expand(ast.expr(), errors, allocator);
-            try expand_from_list(ast.children().*, errors, allocator);
-        },
-        .mapping => {
-            try expand(ast.lhs(), errors, allocator);
-            try expand(ast.rhs(), errors, allocator);
-        },
-        .@"while" => { // TODO: Re-write `while let; cond; post b1 else b2` to be `{let; while cond; post b1 orelse b2}`
-            try expand(ast.@"while".let, errors, allocator);
-            try expand(ast.@"while".condition, errors, allocator);
-            try expand(ast.@"while".post, errors, allocator);
-            try expand(ast.body_block(), errors, allocator);
-            try expand(ast.else_block(), errors, allocator);
-        },
-        .@"for" => {
-            try expand(ast.@"for".let, errors, allocator);
-            try expand(ast.@"for".elem, errors, allocator);
-            try expand(ast.@"for".iterable, errors, allocator);
-            try expand(ast.body_block(), errors, allocator);
-            try expand(ast.else_block(), errors, allocator);
-        },
-        .block => {
-            try expand_from_list(ast.children().*, errors, allocator);
-            if (ast.block.final) |final| {
-                try expand(final, errors, allocator);
-            }
-        },
-
-        .@"return" => try expand(ast.@"return"._ret_expr, errors, allocator),
-        .decl => {
-            try expand(ast.decl.type, errors, allocator);
-            try expand(ast.decl.init, errors, allocator);
-        },
-        .fn_decl => {
-            try expand(ast.fn_decl.init, errors, allocator);
-            try expand_from_list(ast.children().*, errors, allocator);
-            try expand(ast.fn_decl.ret_type, errors, allocator);
-        },
-        .trait => {
-            try expand_from_list(ast.trait.method_decls, errors, allocator);
-            try expand_from_list(ast.trait.const_decls, errors, allocator);
-        },
-        .impl => {
-            try expand(ast.impl._type, errors, allocator);
-            try expand(ast.impl.trait, errors, allocator);
-            try expand_from_list(ast.impl.method_defs, errors, allocator);
-            try expand_from_list(ast.impl.const_defs, errors, allocator);
-        },
-        .method_decl => {
-            try expand(ast.method_decl.init, errors, allocator);
-            try expand_from_list(ast.children().*, errors, allocator);
-            try expand(ast.method_decl.ret_type, errors, allocator);
-        },
-        .@"defer", .@"errdefer" => try expand(ast.statement(), errors, allocator),
     }
+
+    return self;
 }
 
-fn annot_from_ast(ast: *ast_.AST, errors: *errs_.Errors, allocator: std.mem.Allocator) Expand_Error!*ast_.AST {
+fn annot_from_ast(ast: *ast_.AST, errors: *errs_.Errors, allocator: std.mem.Allocator) walk_.Error!*ast_.AST {
     if (ast.* == .annotation) {
         return ast;
     } else if (ast.* == .identifier) {

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -101,14 +101,14 @@ pub const Context = struct {
     }
 
     /// Interprets the interpreter's instructions until the interpreter has executed more return instructions than call
-    /// instructions.
+    /// instructions, and the instruction pointer isn't a trap representation.
     pub fn run(
         self: *Context,
         compiler: *compiler_.Context,
     ) error{CompileError}!void {
-        const call_depth_at_run = self.call_depth;
-        // Halt whenever instruction pointer is greater than the max allowed instructions
-        while (self.call_depth >= call_depth_at_run) : (self.instruction_pointer.inst_idx += 1) {
+        const initial_call_depth = self.call_depth;
+        // Stop whenever has returned more than called, or instruction pointer is not a halt trap representation
+        while (self.call_depth >= initial_call_depth and self.instruction_pointer.inst_idx < halt_trap_instruction) : (self.instruction_pointer.inst_idx += 1) {
             const ir: *ir_.IR = try self.curr_instruction();
             if (debugger) {
                 std.debug.print("\n", .{});

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -46,6 +46,8 @@ pub const Context = struct {
     debug_call_stack: std.ArrayList(span_.Span),
     start_time: i64,
 
+    call_depth: i64,
+
     allocator: std.mem.Allocator,
 
     /// Initializes a new interpreter context.
@@ -61,6 +63,8 @@ pub const Context = struct {
             .debug_call_stack = std.ArrayList(span_.Span).init(allocator),
 
             .start_time = std.time.milliTimestamp(),
+
+            .call_depth = 0,
 
             .allocator = allocator,
         };
@@ -96,20 +100,21 @@ pub const Context = struct {
         self.allocator.free(self.memory);
     }
 
-    /// Interprets the interpreter's instructions until the interpreter's instruction pointer is less than
-    /// the maximum allowed instructions.
-    pub fn interpret(
+    /// Interprets the interpreter's instructions until the interpreter has executed more return instructions than call
+    /// instructions.
+    pub fn run(
         self: *Context,
         compiler: *compiler_.Context,
     ) error{CompileError}!void {
+        const call_depth_at_run = self.call_depth;
         // Halt whenever instruction pointer is greater than the max allowed instructions
-        while (self.instruction_pointer.inst_idx < halt_trap_instruction) : (self.instruction_pointer.inst_idx += 1) {
+        while (self.call_depth >= call_depth_at_run) : (self.instruction_pointer.inst_idx += 1) {
             const ir: *ir_.IR = try self.curr_instruction();
             if (debugger) {
                 std.debug.print("\n", .{});
                 self.print_registers();
                 self.print_stack();
-                std.debug.print("\n\n\n\n{}=> ", .{ir});
+                std.debug.print("\n\n\n\n{s}\n{}=> ", .{ ir.span.line_text, ir });
             }
             const time_now = std.time.milliTimestamp();
             if (!debugger and time_now - self.start_time > timeout_ms) {
@@ -318,12 +323,17 @@ pub const Context = struct {
                     const method_name = symbol.name;
                     if (std.mem.eql(u8, method_name, "find")) {
                         const arg: *lval_.L_Value = ir.data.lval_list.items[@as(usize, @intCast(0))];
-                        const string = self.extract_ast(try self.effective_address(arg), primitives_.string_type, self.allocator);
-                        std.debug.print("searching for package: '{s}'\n", .{string.string.data});
+                        const path_ast = self.extract_ast(try self.effective_address(arg), primitives_.string_type, self.allocator);
                         const current_module_path = (self.curr_module() catch unreachable).absolute_path;
                         const ret_addr = try self.effective_address(ir.dest.?);
-                        if (builtin_.package_find(compiler, self, current_module_path, string.string.data)) |package_address| {
-                            self.store_int(ret_addr, 8, package_address);
+                        if (builtin_.package_find(compiler, self, current_module_path, path_ast.string.data)) |package_info| {
+                            const adrs = package_info.package_adrs;
+                            // Store the directory of the package inside the package struct before returning
+                            const dir_string = self.modules.get(0).?.interned_string_set_add(package_info.package_dirname);
+                            const dir_offset = primitives_.package_type.product.get_offset(2, self.allocator);
+                            self.store(ir_.String_Idx, adrs + dir_offset, dir_string);
+                            // Store the address of the package in the retval
+                            self.store_int(ret_addr, 8, adrs);
                         } else |_| {
                             return self.panic("interpreter error: cannot find package", .{});
                         }
@@ -360,6 +370,7 @@ pub const Context = struct {
     /// Sets up the caller's stack frame, pushes function arguments in reverse order, stores the return value location,
     /// and then jumps to the function's code.
     pub fn call(self: *Context, function_symbol: *symbol_.Symbol, retval_place: *lval_.L_Value, args_list: std.ArrayList(*lval_.L_Value)) error{CompileError}!void {
+        self.call_depth += 1;
         // Save old stack pointer
         const old_sp = self.stack_pointer;
         self.stack_pointer = offsets_.next_alignment(self.stack_pointer, 8); // align stack pointer to 8 before pushing args
@@ -396,6 +407,7 @@ pub const Context = struct {
 
     /// Tears down the stack frame, and jumps back to the caller's location
     inline fn ret(self: *Context) void {
+        self.call_depth -= 1;
         // deallocate locals
         self.stack_pointer = self.base_pointer + 8;
         // jump to return-address
@@ -426,7 +438,10 @@ pub const Context = struct {
         switch (_type.*) {
             .identifier => {
                 const info = primitives_.info_from_name(_type.token().data);
-                switch (info.type_kind) {
+                if (info == null) {
+                    return self.extract_ast(address, _type.symbol().?.init.?, allocator);
+                }
+                switch (info.?.type_kind) {
                     .type => {
                         const stack_value = self.load_unsigned_int(address, 8);
                         if (stack_value == 0xAAAAAAAAAAAAAAAA) { // NOTE: This only works if the interpreter never overwrites this address...
@@ -443,7 +458,7 @@ pub const Context = struct {
                     },
                     .none => unreachable,
                     .boolean => {
-                        const val = self.load_int(address, info.size);
+                        const val = self.load_int(address, info.?.size);
                         if (val == 0) {
                             return ast_.AST.create_false(token_.Token.init_simple("false"), allocator).assert_valid();
                         } else {
@@ -453,7 +468,7 @@ pub const Context = struct {
                     .signed_integer => {
                         const retval = ast_.AST.create_int(
                             token_.Token.init_simple("signed int"),
-                            self.load_int(address, info.size),
+                            self.load_int(address, info.?.size),
                             allocator,
                         ).assert_valid();
                         retval.set_represents(_type);
@@ -462,7 +477,7 @@ pub const Context = struct {
                     .unsigned_integer => {
                         const retval = ast_.AST.create_int(
                             token_.Token.init_simple("unsigned int"),
-                            self.load_int(address, info.size),
+                            self.load_int(address, info.?.size),
                             allocator,
                         ).assert_valid();
                         retval.set_represents(_type);
@@ -471,7 +486,7 @@ pub const Context = struct {
                     .floating_point => {
                         const retval = ast_.AST.create_float(
                             token_.Token.init_simple("float"),
-                            self.load_float(address, info.size),
+                            self.load_float(address, info.?.size),
                             allocator,
                         ).assert_valid();
                         retval.set_represents(_type);
@@ -514,7 +529,7 @@ pub const Context = struct {
                 var value_terms = std.ArrayList(*ast_.AST).init(allocator);
                 errdefer value_terms.deinit();
                 for (0.., _type.children().items) |i, term| {
-                    // std.debug.print("term:{}\n", .{term});
+                    // std.debug.print("term:{}\n", .{i});
                     const offset = _type.product.get_offset(i, allocator);
                     // std.debug.print("offset:{}\n", .{offset});
                     const extracted_term = self.extract_ast(address + offset, term, allocator);
@@ -550,7 +565,11 @@ pub const Context = struct {
 
     /// Prints the contents of the interpreter's stack. Used for debugging.
     fn print_stack(self: *Context) void {
-        for (0..@as(usize, @intCast(self.stack_pointer))) |i| {
+        self.print_memory(0, @as(usize, @intCast(self.stack_pointer)));
+    }
+
+    fn print_memory(self: *Context, start: usize, end: usize) void {
+        for (start..end) |i| {
             if (@rem(i, 8) == 0) {
                 std.debug.print("0x{0X:0>2.}: ", .{i});
             }
@@ -577,7 +596,7 @@ pub const Context = struct {
         return module.instructions.items[@as(usize, @intCast(self.instruction_pointer.inst_idx))];
     }
 
-    fn curr_module(self: *Context) error{CompileError}!*module_.Module {
+    pub fn curr_module(self: *Context) error{CompileError}!*module_.Module {
         return self.modules.get(self.instruction_pointer.module_uid) orelse
             self.panic("interpreter error: attempt to use module 0x{X}, which hasn't been loaded yet\n", .{self.instruction_pointer.module_uid});
     }

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -330,7 +330,7 @@ pub const Context = struct {
                             const adrs = package_info.package_adrs;
                             // Store the directory of the package inside the package struct before returning
                             const dir_string = self.modules.get(0).?.interned_string_set_add(package_info.package_dirname);
-                            const dir_offset = primitives_.package_type.product.get_offset(2, self.allocator);
+                            const dir_offset = primitives_.package_type.product.get_offset_field("dir", self.allocator);
                             self.store(ir_.String_Idx, adrs + dir_offset, dir_string);
                             // Store the address of the package in the retval
                             self.store_int(ret_addr, 8, adrs);

--- a/src/lower.zig
+++ b/src/lower.zig
@@ -445,12 +445,12 @@ fn lower_AST(
             defer return_labels.deinit();
             var error_labels = std.ArrayList(*ir_.IR).init(allocator);
             defer error_labels.deinit();
-            for (ast.block.scope.?.defers.items) |_| {
+            for (ast.scope().?.defers.items) |_| {
                 continue_labels.append(ir_.IR.init_label(cfg, ast.token().span, allocator)) catch unreachable;
                 break_labels.append(ir_.IR.init_label(cfg, ast.token().span, allocator)) catch unreachable;
                 return_labels.append(ir_.IR.init_label(cfg, ast.token().span, allocator)) catch unreachable;
             }
-            for (ast.block.scope.?.errdefers.items) |_| {
+            for (ast.scope().?.errdefers.items) |_| {
                 error_labels.append(ir_.IR.init_label(cfg, ast.token().span, allocator)) catch unreachable;
             }
             const end_label = ir_.IR.init_label(cfg, ast.token().span, allocator);
@@ -481,16 +481,16 @@ fn lower_AST(
                 wrap_error_return(_temp, cfg, ast.token().span, current_labels, allocator);
             }
 
-            try generate_defers(cfg, &ast.block.scope.?.defers, &continue_labels, errors, allocator);
+            try generate_defers(cfg, &ast.scope().?.defers, &continue_labels, errors, allocator);
             cfg.append_instruction(ir_.IR.init_jump(end_label, ast.token().span, allocator));
 
-            try generate_defers(cfg, &ast.block.scope.?.defers, &break_labels, errors, allocator);
+            try generate_defers(cfg, &ast.scope().?.defers, &break_labels, errors, allocator);
             cfg.append_instruction(ir_.IR.init_jump(labels.break_label, ast.token().span, allocator));
 
-            try generate_defers(cfg, &ast.block.scope.?.defers, &return_labels, errors, allocator);
+            try generate_defers(cfg, &ast.scope().?.defers, &return_labels, errors, allocator);
             cfg.append_instruction(ir_.IR.init_jump(labels.return_label, ast.token().span, allocator));
 
-            try generate_defers(cfg, &ast.block.scope.?.errdefers, &error_labels, errors, allocator);
+            try generate_defers(cfg, &ast.scope().?.errdefers, &error_labels, errors, allocator);
             cfg.append_instruction(ir_.IR.init_jump(labels.error_label, ast.token().span, allocator));
 
             cfg.append_instruction(end_label);

--- a/src/main.zig
+++ b/src/main.zig
@@ -113,13 +113,16 @@ fn make_package(
         }
         const requirement = maybe_requirement_addr.sum_value.init.?;
         const required_package_addr: i64 = @intCast(requirement.children().items[1].int.data);
-        // const requirement_name = requirement.children().items[0].string.data; // TODO: Will need this
+        const requirement_name = requirement.children().items[0].string.data;
         const required_package = interpreter.extract_ast(required_package_addr, primitives_.package_type, compiler.allocator());
         const required_package_dir = required_package.children().items[2].string.data;
 
         const new_working_directory_buffer = compiler.allocator().alloc(u8, std.fs.MAX_PATH_BYTES) catch unreachable;
         const new_working_directory = std.fs.cwd().realpath(required_package_dir, new_working_directory_buffer) catch unreachable;
-        _ = try make_package(required_package, compiler, interpreter, new_working_directory, null);
+        const module = try make_package(required_package, compiler, interpreter, new_working_directory, null);
+
+        compiler.register_package( // TODO: These should be package-specific
+            requirement_name, module);
     }
 
     const root_filename = package.children().items[0].string.data;

--- a/src/main.zig
+++ b/src/main.zig
@@ -122,8 +122,7 @@ fn make_package(
         const new_working_directory = std.fs.cwd().realpath(required_package_dir, new_working_directory_buffer) catch unreachable;
         const module = try make_package(required_package, required_package_name, compiler, interpreter, new_working_directory, null);
 
-        compiler.register_package( // TODO: These should be package-specific
-            package_name, requirement_name, module);
+        compiler.register_package(package_name, requirement_name, module);
     }
 
     const root_filename = package.get_field(primitives_.package_type, "root").string.data;

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,8 +70,6 @@ fn build(name: []const u8, args: *std.process.ArgIterator, allocator: std.mem.Al
     // Get the path
     const build_path_buffer = std.heap.page_allocator.alloc(u8, std.fs.MAX_PATH_BYTES) catch unreachable;
     defer std.heap.page_allocator.free(build_path_buffer);
-    const root_path_buffer = std.heap.page_allocator.alloc(u8, std.fs.MAX_PATH_BYTES) catch unreachable;
-    defer std.heap.page_allocator.free(root_path_buffer);
 
     const build_path = std.fs.cwd().realpath("build.orng", build_path_buffer) catch |err| switch (err) {
         error.FileNotFound => {
@@ -88,38 +86,50 @@ fn build(name: []const u8, args: *std.process.ArgIterator, allocator: std.mem.Al
     const build_cfg = compiler.compile_build_file(build_path) catch return error.CompileError;
 
     var interpreter = interpreter_.Context.init(compiler.allocator());
-    interpreter.set_entry_point(build_cfg, primitives_.package_type);
-    try interpreter.interpret(compiler);
+    interpreter.set_entry_point(build_cfg, primitives_.package_type.expand_type(compiler.allocator()));
+    try interpreter.run(compiler);
     defer interpreter.deinit();
 
     // Extract the retval
-    var result = interpreter.extract_ast(0, primitives_.package_type, allocator);
-    const root_name = print_package_name(result);
-    for (result.children().items[2].children().items) |item| {
-        if (item.sum_value._pos != 0) {
-            continue;
-        }
-        const dependency_addr: i64 = @intCast(item.sum_value.init.?.int.data);
-        const dependency = interpreter.extract_ast(dependency_addr, primitives_.package_type, allocator);
-        _ = print_package_name(dependency);
-    }
-    const root_file_path = std.fs.cwd().realpath(root_name, root_path_buffer) catch return error.CompileError;
-
-    const root_module = compiler.compile_module(
-        root_file_path,
-        "main",
-        false,
-    ) catch return error.CompileError;
-    _ = root_module; // autofix
+    const package_dag = interpreter.extract_ast(0, primitives_.package_type, allocator);
+    const cwd_buffer = compiler.allocator().alloc(u8, std.fs.MAX_PATH_BYTES) catch unreachable;
+    const cwd = std.fs.cwd().realpath(".", cwd_buffer) catch unreachable;
+    _ = try make_package(package_dag, compiler, &interpreter, cwd, "main");
 
     // std.fs.cwd().makeDir("build") catch return error.CompileError;
     // compiler.loop_modules();
 }
 
-fn print_package_name(package: *ast_.AST) []const u8 {
-    const retval = package.children().items[0].string.data;
-    std.debug.print("root: {s}\n", .{retval});
-    return retval;
+fn make_package(
+    package: *ast_.AST,
+    compiler: *compiler_.Context,
+    interpreter: *interpreter_.Context,
+    working_directory: []const u8,
+    entry_name: ?[]const u8,
+) Command_Error!*module_.Module {
+    for (package.children().items[3].children().items) |maybe_requirement_addr| {
+        if (maybe_requirement_addr.sum_value._pos != 0) {
+            continue;
+        }
+        const requirement = maybe_requirement_addr.sum_value.init.?;
+        const required_package_addr: i64 = @intCast(requirement.children().items[1].int.data);
+        // const requirement_name = requirement.children().items[0].string.data; // TODO: Will need this
+        const required_package = interpreter.extract_ast(required_package_addr, primitives_.package_type, compiler.allocator());
+        const required_package_dir = required_package.children().items[2].string.data;
+
+        const new_working_directory_buffer = compiler.allocator().alloc(u8, std.fs.MAX_PATH_BYTES) catch unreachable;
+        const new_working_directory = std.fs.cwd().realpath(required_package_dir, new_working_directory_buffer) catch unreachable;
+        _ = try make_package(required_package, compiler, interpreter, new_working_directory, null);
+    }
+
+    const root_filename = package.children().items[0].string.data;
+    const root_file_paths = [_][]const u8{ working_directory, root_filename };
+    const root_file_path = std.fs.path.join(compiler.allocator(), &root_file_paths) catch unreachable;
+    return compiler.compile_module(
+        root_file_path,
+        entry_name,
+        false,
+    ) catch error.CompileError;
 }
 
 fn print_version(name: []const u8, args: *std.process.ArgIterator, allocator: std.mem.Allocator) Command_Error!void {

--- a/src/module.zig
+++ b/src/module.zig
@@ -556,7 +556,7 @@ pub fn interpret(
     context.set_entry_point(cfg, ret_type);
     defer context.deinit();
     context.load_module(module);
-    try context.interpret(compiler);
+    try context.run(compiler);
 
     // Extract the retval
     return context.extract_ast(0, ret_type, compiler.allocator());

--- a/src/module.zig
+++ b/src/module.zig
@@ -270,11 +270,12 @@ pub const Module = struct {
                 const package_path = std.fs.path.dirname(self.absolute_path).?;
                 var import_filename = String.init(compiler.allocator());
                 defer import_filename.deinit();
-                import_filename.writer().print("{s}.orng", .{ast.decl.pattern.pattern_symbol.name}) catch unreachable;
+                const import_name = ast.decl.pattern.pattern_symbol.name;
+                import_filename.writer().print("{s}.orng", .{import_name}) catch unreachable;
                 const import_file_paths = [_][]const u8{ package_path, import_filename.str() };
                 const import_file_path = std.fs.path.join(compiler.allocator(), &import_file_paths) catch unreachable;
                 _ = compiler.compile_module(import_file_path, null, false) catch |err| switch (err) {
-                    error.FileNotFound => {
+                    error.FileNotFound => if (compiler.packages.get(import_name) == null) {
                         compiler.errors.add_error(.{ .import_file_not_found = .{
                             .filename = ast.decl.pattern.pattern_symbol.name,
                             .span = ast.token().span,

--- a/src/module.zig
+++ b/src/module.zig
@@ -51,6 +51,9 @@ pub const Module = struct {
     // Absolute path of the module
     absolute_path: []const u8,
 
+    // The name of the package this module belongs to
+    package_name: []const u8,
+
     // A graph of type dependencies
     type_set: type_set_.Type_Set,
 
@@ -84,6 +87,7 @@ pub const Module = struct {
         module_uids += 1;
         retval.name = name;
         retval.absolute_path = absolute_path;
+        retval.package_name = std.fs.path.basename(std.fs.path.dirname(absolute_path).?);
         retval.interned_strings = std.ArrayList([]const u8).init(allocator);
         retval.scope = scope;
         retval.allocator = allocator;

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -417,7 +417,7 @@ fn create_prelude(compiler: *compiler_.Context) !void {
     defer errors.deinit();
     errdefer errors.print_errors();
 
-    const module = module_.Module.init("prelude", "", prelude.?, compiler.allocator());
+    const module = module_.Module.init("prelude", "prelude/prelude.orng", prelude.?, compiler.allocator());
     prelude.?.module = module;
     try module_.Module.fill_contents(
         prelude_contents,

--- a/src/walker.zig
+++ b/src/walker.zig
@@ -7,19 +7,25 @@ pub fn Pass(comptime ctx: type) type {
     return *const fn (*ast_.AST, ctx) Error!ctx;
 }
 
-pub fn walk_asts(asts: std.ArrayList(*ast_.AST), context: anytype, pass: Pass(@TypeOf(context))) Error!void {
+pub fn walk_asts(asts: std.ArrayList(*ast_.AST), context: anytype) Error!void {
     for (asts.items) |ast| {
-        try walk_ast(ast, context, pass);
+        try walk_ast(ast, context);
     }
 }
 
-// A function that walks over an AST, applying pass's function to each one
-pub fn walk_ast(maybe_ast: ?*ast_.AST, context: anytype, pass: Pass(@TypeOf(context))) Error!void {
+// A function that walks over an AST, applying prefix, postfix's function to each one
+// try YOUR_FUNCTION_HERE\(.*, (?!al|er|sco)
+// ^(?! *(try YOUR_FUNCTION_HERE|\}|\.|=>|//)).*
+pub fn walk_ast(maybe_ast: ?*ast_.AST, context: anytype) Error!void {
     if (maybe_ast == null) {
         return;
     }
     const ast = maybe_ast.?;
-    const new_context = try pass(ast, context);
+
+    var new_context = context;
+    if (@hasDecl(@TypeOf(context), "prefix")) {
+        new_context = try context.prefix(ast);
+    }
 
     switch (ast.*) {
         .anyptr_type,
@@ -55,7 +61,7 @@ pub fn walk_ast(maybe_ast: ?*ast_.AST, context: anytype, pass: Pass(@TypeOf(cont
         .slice_of,
         .dyn_type,
         .dyn_value,
-        => try walk_ast(ast.expr(), new_context, pass),
+        => try walk_ast(ast.expr(), new_context),
 
         .assign,
         .@"or",
@@ -79,101 +85,104 @@ pub fn walk_ast(maybe_ast: ?*ast_.AST, context: anytype, pass: Pass(@TypeOf(cont
         .function,
         .@"union",
         => {
-            try walk_ast(ast.lhs(), new_context, pass);
-            try walk_ast(ast.rhs(), new_context, pass);
+            try walk_ast(ast.lhs(), new_context);
+            try walk_ast(ast.rhs(), new_context);
         },
         .invoke => {
-            try walk_ast(ast.lhs(), new_context, pass);
-            try walk_ast(ast.rhs(), new_context, pass);
-            try walk_asts(ast.children().*, new_context, pass);
+            try walk_ast(ast.lhs(), new_context);
+            try walk_ast(ast.rhs(), new_context);
+            try walk_asts(ast.children().*, new_context);
         },
         .call => {
-            try walk_ast(ast.lhs(), new_context, pass);
-            try walk_asts(ast.children().*, new_context, pass);
+            try walk_ast(ast.lhs(), new_context);
+            try walk_asts(ast.children().*, new_context);
         },
-        .sum_type, .product => try walk_asts(ast.children().*, new_context, pass),
+        .sum_type, .product => try walk_asts(ast.children().*, new_context),
         .sum_value => {
-            try walk_ast(ast.sum_value.init, new_context, pass);
-            try walk_ast(ast.sum_value.base, new_context, pass);
+            try walk_ast(ast.sum_value.init, new_context);
+            try walk_ast(ast.sum_value.base, new_context);
         },
         .array_of => {
-            try walk_ast(ast.expr(), new_context, pass);
-            try walk_ast(ast.array_of.len, new_context, pass);
+            try walk_ast(ast.expr(), new_context);
+            try walk_ast(ast.array_of.len, new_context);
         },
         .sub_slice => {
-            try walk_ast(ast.sub_slice.super, new_context, pass);
-            try walk_ast(ast.sub_slice.lower, new_context, pass);
-            try walk_ast(ast.sub_slice.upper, new_context, pass);
+            try walk_ast(ast.sub_slice.super, new_context);
+            try walk_ast(ast.sub_slice.lower, new_context);
+            try walk_ast(ast.sub_slice.upper, new_context);
         },
         .annotation => {
-            try walk_ast(ast.annotation.type, new_context, pass);
-            try walk_ast(ast.annotation.predicate, new_context, pass);
-            try walk_ast(ast.annotation.init, new_context, pass);
+            try walk_ast(ast.annotation.type, new_context);
+            try walk_ast(ast.annotation.predicate, new_context);
+            try walk_ast(ast.annotation.init, new_context);
         },
         .@"if" => {
-            try walk_ast(ast.@"if".let, new_context, pass);
-            try walk_ast(ast.@"if".condition, new_context, pass);
-            try walk_ast(ast.body_block(), new_context, pass);
-            try walk_ast(ast.else_block(), new_context, pass);
+            try walk_ast(ast.@"if".let, new_context);
+            try walk_ast(ast.@"if".condition, new_context);
+            try walk_ast(ast.body_block(), new_context);
+            try walk_ast(ast.else_block(), new_context);
         },
         .match => {
-            try walk_ast(ast.match.let, new_context, pass);
-            try walk_ast(ast.expr(), new_context, pass);
-            try walk_asts(ast.children().*, new_context, pass);
+            try walk_ast(ast.match.let, new_context);
+            try walk_ast(ast.expr(), new_context);
+            try walk_asts(ast.children().*, new_context);
         },
         .mapping => {
-            try walk_ast(ast.lhs(), new_context, pass);
-            try walk_ast(ast.rhs(), new_context, pass);
+            try walk_ast(ast.lhs(), new_context);
+            try walk_ast(ast.rhs(), new_context);
         },
         .@"while" => {
-            try walk_ast(ast.@"while".let, new_context, pass);
-            try walk_ast(ast.@"while".condition, new_context, pass);
-            try walk_ast(ast.@"while".post, new_context, pass);
-            try walk_ast(ast.body_block(), new_context, pass);
-            try walk_ast(ast.else_block(), new_context, pass);
+            try walk_ast(ast.@"while".let, new_context);
+            try walk_ast(ast.@"while".condition, new_context);
+            try walk_ast(ast.@"while".post, new_context);
+            try walk_ast(ast.body_block(), new_context);
+            try walk_ast(ast.else_block(), new_context);
         },
         .@"for" => {
-            try walk_ast(ast.@"for".let, new_context, pass);
-            try walk_ast(ast.@"for".elem, new_context, pass);
-            try walk_ast(ast.@"for".iterable, new_context, pass);
-            try walk_ast(ast.body_block(), new_context, pass);
-            try walk_ast(ast.else_block(), new_context, pass);
+            try walk_ast(ast.@"for".let, new_context);
+            try walk_ast(ast.@"for".elem, new_context);
+            try walk_ast(ast.@"for".iterable, new_context);
+            try walk_ast(ast.body_block(), new_context);
+            try walk_ast(ast.else_block(), new_context);
         },
         .block => {
-            // std.debug.print("{}\n", .{ast.token().span}, pass);
-            try walk_asts(ast.children().*, new_context, pass);
+            try walk_asts(ast.children().*, new_context);
             if (ast.block.final) |final| {
-                try walk_ast(final, new_context, pass);
+                try walk_ast(final, new_context);
             }
         },
-        .@"return" => try walk_ast(ast.@"return"._ret_expr, new_context, pass),
+        .@"return" => try walk_ast(ast.@"return"._ret_expr, new_context),
         .decl => {
-            try walk_ast(ast.decl.type, new_context, pass);
-            try walk_ast(ast.decl.init, new_context, pass);
+            try walk_ast(ast.decl.type, new_context);
+            try walk_ast(ast.decl.init, new_context);
             for (ast.decl.symbols.items) |symbol| {
                 symbol.defined = true;
             }
         },
         .fn_decl => {
-            try walk_ast(ast.fn_decl.init, new_context, pass);
-            try walk_asts(ast.children().*, new_context, pass);
-            try walk_ast(ast.fn_decl.ret_type, new_context, pass);
+            try walk_ast(ast.fn_decl.init, new_context);
+            try walk_asts(ast.children().*, new_context);
+            try walk_ast(ast.fn_decl.ret_type, new_context);
         },
         .trait => {
-            try walk_asts(ast.trait.method_decls, new_context, pass);
-            try walk_asts(ast.trait.const_decls, new_context, pass);
+            try walk_asts(ast.trait.method_decls, new_context);
+            try walk_asts(ast.trait.const_decls, new_context);
         },
         .impl => {
-            try walk_ast(ast.impl._type, new_context, pass);
-            try walk_ast(ast.impl.trait, new_context, pass);
-            try walk_asts(ast.impl.method_defs, new_context, pass);
-            try walk_asts(ast.impl.const_defs, new_context, pass);
+            try walk_ast(ast.impl._type, new_context);
+            try walk_ast(ast.impl.trait, new_context);
+            try walk_asts(ast.impl.method_defs, new_context);
+            try walk_asts(ast.impl.const_defs, new_context);
         },
         .method_decl => {
-            try walk_ast(ast.method_decl.init, new_context, pass);
-            try walk_asts(ast.children().*, new_context, pass);
-            try walk_ast(ast.method_decl.ret_type, new_context, pass);
+            try walk_ast(ast.method_decl.init, new_context);
+            try walk_asts(ast.children().*, new_context);
+            try walk_ast(ast.method_decl.ret_type, new_context);
         },
-        .@"defer", .@"errdefer" => try walk_ast(ast.statement(), new_context, pass),
+        .@"defer", .@"errdefer" => try walk_ast(ast.statement(), new_context),
+    }
+
+    if (@hasDecl(@TypeOf(context), "postfix")) {
+        try context.postfix(ast);
     }
 }

--- a/src/walker.zig
+++ b/src/walker.zig
@@ -1,0 +1,179 @@
+const std = @import("std");
+const ast_ = @import("ast.zig");
+
+pub const Error = error{CompileError};
+
+pub fn Pass(comptime ctx: type) type {
+    return *const fn (*ast_.AST, ctx) Error!ctx;
+}
+
+pub fn walk_asts(asts: std.ArrayList(*ast_.AST), context: anytype, pass: Pass(@TypeOf(context))) Error!void {
+    for (asts.items) |ast| {
+        try walk_ast(ast, context, pass);
+    }
+}
+
+// A function that walks over an AST, applying pass's function to each one
+pub fn walk_ast(maybe_ast: ?*ast_.AST, context: anytype, pass: Pass(@TypeOf(context))) Error!void {
+    if (maybe_ast == null) {
+        return;
+    }
+    const ast = maybe_ast.?;
+    const new_context = try pass(ast, context);
+
+    switch (ast.*) {
+        .anyptr_type,
+        .unit_type,
+        .unit_value,
+        .int,
+        .char,
+        .float,
+        .string,
+        .field,
+        .@"unreachable",
+        .true,
+        .false,
+        .@"break",
+        .@"continue",
+        .poison,
+        .pattern_symbol,
+        .domain_of,
+        .receiver,
+        .template,
+        .identifier,
+        => {},
+
+        .type_of,
+        .default,
+        .size_of,
+        .not,
+        .negate,
+        .dereference,
+        .@"try",
+        .@"comptime",
+        .addr_of,
+        .slice_of,
+        .dyn_type,
+        .dyn_value,
+        => try walk_ast(ast.expr(), new_context, pass),
+
+        .assign,
+        .@"or",
+        .@"and",
+        .add,
+        .sub,
+        .mult,
+        .div,
+        .mod,
+        .equal,
+        .not_equal,
+        .greater,
+        .lesser,
+        .greater_equal,
+        .lesser_equal,
+        .@"catch",
+        .@"orelse",
+        .index,
+        .select,
+        .access,
+        .function,
+        .@"union",
+        => {
+            try walk_ast(ast.lhs(), new_context, pass);
+            try walk_ast(ast.rhs(), new_context, pass);
+        },
+        .invoke => {
+            try walk_ast(ast.lhs(), new_context, pass);
+            try walk_ast(ast.rhs(), new_context, pass);
+            try walk_asts(ast.children().*, new_context, pass);
+        },
+        .call => {
+            try walk_ast(ast.lhs(), new_context, pass);
+            try walk_asts(ast.children().*, new_context, pass);
+        },
+        .sum_type, .product => try walk_asts(ast.children().*, new_context, pass),
+        .sum_value => {
+            try walk_ast(ast.sum_value.init, new_context, pass);
+            try walk_ast(ast.sum_value.base, new_context, pass);
+        },
+        .array_of => {
+            try walk_ast(ast.expr(), new_context, pass);
+            try walk_ast(ast.array_of.len, new_context, pass);
+        },
+        .sub_slice => {
+            try walk_ast(ast.sub_slice.super, new_context, pass);
+            try walk_ast(ast.sub_slice.lower, new_context, pass);
+            try walk_ast(ast.sub_slice.upper, new_context, pass);
+        },
+        .annotation => {
+            try walk_ast(ast.annotation.type, new_context, pass);
+            try walk_ast(ast.annotation.predicate, new_context, pass);
+            try walk_ast(ast.annotation.init, new_context, pass);
+        },
+        .@"if" => {
+            try walk_ast(ast.@"if".let, new_context, pass);
+            try walk_ast(ast.@"if".condition, new_context, pass);
+            try walk_ast(ast.body_block(), new_context, pass);
+            try walk_ast(ast.else_block(), new_context, pass);
+        },
+        .match => {
+            try walk_ast(ast.match.let, new_context, pass);
+            try walk_ast(ast.expr(), new_context, pass);
+            try walk_asts(ast.children().*, new_context, pass);
+        },
+        .mapping => {
+            try walk_ast(ast.lhs(), new_context, pass);
+            try walk_ast(ast.rhs(), new_context, pass);
+        },
+        .@"while" => {
+            try walk_ast(ast.@"while".let, new_context, pass);
+            try walk_ast(ast.@"while".condition, new_context, pass);
+            try walk_ast(ast.@"while".post, new_context, pass);
+            try walk_ast(ast.body_block(), new_context, pass);
+            try walk_ast(ast.else_block(), new_context, pass);
+        },
+        .@"for" => {
+            try walk_ast(ast.@"for".let, new_context, pass);
+            try walk_ast(ast.@"for".elem, new_context, pass);
+            try walk_ast(ast.@"for".iterable, new_context, pass);
+            try walk_ast(ast.body_block(), new_context, pass);
+            try walk_ast(ast.else_block(), new_context, pass);
+        },
+        .block => {
+            // std.debug.print("{}\n", .{ast.token().span}, pass);
+            try walk_asts(ast.children().*, new_context, pass);
+            if (ast.block.final) |final| {
+                try walk_ast(final, new_context, pass);
+            }
+        },
+        .@"return" => try walk_ast(ast.@"return"._ret_expr, new_context, pass),
+        .decl => {
+            try walk_ast(ast.decl.type, new_context, pass);
+            try walk_ast(ast.decl.init, new_context, pass);
+            for (ast.decl.symbols.items) |symbol| {
+                symbol.defined = true;
+            }
+        },
+        .fn_decl => {
+            try walk_ast(ast.fn_decl.init, new_context, pass);
+            try walk_asts(ast.children().*, new_context, pass);
+            try walk_ast(ast.fn_decl.ret_type, new_context, pass);
+        },
+        .trait => {
+            try walk_asts(ast.trait.method_decls, new_context, pass);
+            try walk_asts(ast.trait.const_decls, new_context, pass);
+        },
+        .impl => {
+            try walk_ast(ast.impl._type, new_context, pass);
+            try walk_ast(ast.impl.trait, new_context, pass);
+            try walk_asts(ast.impl.method_defs, new_context, pass);
+            try walk_asts(ast.impl.const_defs, new_context, pass);
+        },
+        .method_decl => {
+            try walk_ast(ast.method_decl.init, new_context, pass);
+            try walk_asts(ast.children().*, new_context, pass);
+            try walk_ast(ast.method_decl.ret_type, new_context, pass);
+        },
+        .@"defer", .@"errdefer" => try walk_ast(ast.statement(), new_context, pass),
+    }
+}

--- a/std/build.orng
+++ b/std/build.orng
@@ -1,3 +1,5 @@
 fn build() -> Package {
-    Package::static_library(.root="lib.orng")
+    let mut retval = Package::static_library(.root="lib.orng")
+    retval.>requires("core", Package::find("core"))
+    retval
 }

--- a/std/core/build.orng
+++ b/std/core/build.orng
@@ -1,0 +1,3 @@
+fn build() -> Package {
+    Package::static_library(.root="lib.orng")
+}

--- a/std/core/lib.orng
+++ b/std/core/lib.orng
@@ -1,0 +1,1 @@
+fn add(x: Int, y: Int) -> Int { x + y }

--- a/std/debug.orng
+++ b/std/debug.orng
@@ -1,7 +1,7 @@
 extern const putchar: Byte -> Int32
 
 fn print(s: String) -> () {
-    while let i = 0; i < s.length; i += 1 {
+    while let mut i = 0; i < s.length; i += 1 {
         _ = putchar(s[i])
     }
 }
@@ -14,9 +14,9 @@ fn println(s: String) -> () {
 fn assert(cond: Bool, reason: ?String = .none) -> () {
     if not cond {
         print("assertion failed")
-        if reason != null {
+        if reason != .none {
             print(": ")
-            print(reason)
+            print(reason.some)
         }
         print("\n")
         unreachable

--- a/std/lib.orng
+++ b/std/lib.orng
@@ -1,1 +1,3 @@
 import debug
+
+const println = debug::println


### PR DESCRIPTION
This PR allows for the importing of packages that were required by the package during building. 
1. Interpreters now yield once they've `ret`'d more than they've `call`'d. This allows interpreters to call into builtin Zig functions, which can then hand control to an Orng function until it returns.
2. Primitive lookup can fail
3. The directory name a package is in is now stored in packages loaded with `find`