### PR TITLE
Add multi-item pointers

### DIFF
--- a/src/ast-validate.zig
+++ b/src/ast-validate.zig
@@ -1953,6 +1953,8 @@ fn assert_mutable(ast: *ast_.AST, errors: *errs_.Errors, allocator: std.mem.Allo
             const lhs_type = ast.lhs().typeof(allocator);
             if (lhs_type.* == .product and lhs_type.product.was_slice) {
                 try assert_mutable_address(lhs_type.children().items[0].annotation.type, errors);
+            } else if (lhs_type.* == .addr_of and lhs_type.addr_of.multiptr) {
+                try assert_mutable_address(lhs_type, errors);
             } else {
                 try assert_mutable(ast.lhs(), errors, allocator);
             }
@@ -1964,7 +1966,7 @@ fn assert_mutable(ast: *ast_.AST, errors: *errs_.Errors, allocator: std.mem.Allo
 
         .select => try assert_mutable(ast.lhs(), errors, allocator),
 
-        else => unreachable,
+        else => {},
     }
 }
 

--- a/src/errors.zig
+++ b/src/errors.zig
@@ -598,7 +598,7 @@ pub const Errors = struct {
 
     pub fn add_error(self: *Errors, err: Error) void {
         self.errors_list.append(err) catch unreachable;
-        err.peek_error(); // uncomment if you want to see where errors come from TODO: Make this a cmd line flag
+        // err.peek_error(); // uncomment if you want to see where errors come from TODO: Make this a cmd line flag
     }
 
     pub fn print_errors(self: *Errors) void {

--- a/src/errors.zig
+++ b/src/errors.zig
@@ -598,7 +598,7 @@ pub const Errors = struct {
 
     pub fn add_error(self: *Errors, err: Error) void {
         self.errors_list.append(err) catch unreachable;
-        // err.peek_error(); // uncomment if you want to see where errors come from TODO: Make this a cmd line flag
+        err.peek_error(); // uncomment if you want to see where errors come from TODO: Make this a cmd line flag
     }
 
     pub fn print_errors(self: *Errors) void {

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -711,9 +711,7 @@ pub const Parser = struct {
             var slice_kind: enum { multiptr, array, slice } = undefined;
             var mut = false;
             var len: ?*ast_.AST = null;
-            if (self.accept(.mut)) |_| {
-                mut = true;
-            } else if (self.accept(.star)) |_| {
+            if (self.accept(.star)) |_| {
                 slice_kind = .multiptr;
             } else if (self.next_is_expr()) {
                 slice_kind = .array;
@@ -724,6 +722,9 @@ pub const Parser = struct {
                 }
             } else {
                 slice_kind = .slice;
+            }
+            if (self.accept(.mut)) |_| {
+                mut = true;
             }
             if (self.peek_kind(.right_square)) {
                 _ = self.expect(.right_square) catch {};

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -705,13 +705,14 @@ pub const Parser = struct {
                     self.allocator,
                 );
             } else {
-                return ast_.AST.create_addr_of(token, try self.prefix_expr(), mut != null, self.allocator);
+                return ast_.AST.create_addr_of(token, try self.prefix_expr(), mut != null, false, self.allocator);
             }
         } else if (self.accept(.left_square)) |token| {
-            var slice_kind: ast_.Slice_Kind = undefined;
+            var slice_kind: enum { multiptr, array, slice } = undefined;
+            var mut = false;
             var len: ?*ast_.AST = null;
             if (self.accept(.mut)) |_| {
-                slice_kind = .mut;
+                mut = true;
             } else if (self.accept(.star)) |_| {
                 slice_kind = .multiptr;
             } else if (self.next_is_expr()) {
@@ -730,10 +731,10 @@ pub const Parser = struct {
                 self.errors.add_error(errs_.Error{ .missing_close = .{ .expected = .right_square, .got = self.peek(), .open = token } });
                 return error.ParseError;
             }
-            if (slice_kind == .array) {
-                return ast_.AST.create_array_of(token, try self.prefix_expr(), len.?, self.allocator);
-            } else {
-                return ast_.AST.create_slice_of(token, try self.prefix_expr(), slice_kind, self.allocator);
+            switch (slice_kind) {
+                .multiptr => return ast_.AST.create_addr_of(token, try self.prefix_expr(), mut, true, self.allocator),
+                .slice => return ast_.AST.create_slice_of(token, try self.prefix_expr(), mut, self.allocator),
+                .array => return ast_.AST.create_array_of(token, try self.prefix_expr(), len.?, self.allocator),
             }
         } else if (self.accept(.question_mark)) |_| {
             return ast_.AST.create_optional_type(try self.prefix_expr(), self.allocator);

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -512,7 +512,7 @@ fn create_prelude(compiler: *compiler_.Context) !void {
 
     package_type = module.top_level_scope().lookup("Package", .{}).found.init.?;
     _ = module.top_level_scope().lookup("Requirement", .{}).found.init.?;
-    addr_package_type = ast_.AST.create_addr_of(package_type.token(), package_type, false, compiler.allocator());
+    addr_package_type = ast_.AST.create_addr_of(package_type.token(), package_type, false, false, compiler.allocator());
 }
 
 fn create_primitive_identifier(name: []const u8, allocator: std.mem.Allocator) *ast_.AST {

--- a/src/symbol-tree.zig
+++ b/src/symbol-tree.zig
@@ -520,8 +520,8 @@ fn extract_domain_with_receiver(impl_type: *ast_.AST, receiver: *ast_.AST, param
 
 fn create_receiver_addr(impl_type: *ast_.AST, receiver: *ast_.AST, allocator: std.mem.Allocator) *ast_.AST {
     return switch (receiver.receiver.kind) {
-        .value, .addr_of => ast_.AST.create_addr_of(receiver.token(), impl_type, false, allocator),
-        .mut_addr_of => ast_.AST.create_addr_of(receiver.token(), impl_type, true, allocator),
+        .value, .addr_of => ast_.AST.create_addr_of(receiver.token(), impl_type, false, false, allocator),
+        .mut_addr_of => ast_.AST.create_addr_of(receiver.token(), impl_type, true, false, allocator),
     };
 }
 

--- a/std/debug.inc
+++ b/std/debug.inc
@@ -116,6 +116,7 @@ inline static int64_t $add_int64_t(const int64_t lhs, const int64_t rhs, const c
         ((rhs < 0) && (lhs < (INT64_MIN - rhs))))
     {
         $lines[$line_idx++] = line;
+        fprintf(stderr, "%d + %d\n", lhs, rhs);
         $panic("addition overflow");
     }
     return lhs + rhs;

--- a/tests/integration/slices/multi_ptr.orng
+++ b/tests/integration/slices/multi_ptr.orng
@@ -1,0 +1,6 @@
+// 337
+fn main() -> Int {
+    let xs: []Int = [](37, 2, 300, 4)
+    let xs_data: [*]Int = xs.data
+    xs_data[0] + xs_data[2] // multi-ptrs can be dereferenced to get the first, or indexed
+}

--- a/tests/integration/slices/multi_ptr_mut.orng
+++ b/tests/integration/slices/multi_ptr_mut.orng
@@ -1,0 +1,10 @@
+// 338
+fn main() -> Int {
+    let xs: [mut]Int = [mut](37, 2, 300, 4)
+    adjust_1(xs.data)
+    xs[1]
+}
+
+fn adjust_1(xs: [*mut]Int) -> () {
+    xs[1] = 338
+}


### PR DESCRIPTION
This PR adds multi-item pointers. Multi-item pointers are like slices in that they refer to many objects, however they are different in that they do not contain length information. They are exactly equivalent to C pointers, and as such their main role is for C interop. 