### PR TITLE
Add incremental builds

### DIFF
--- a/examples/externs.orng
+++ b/examples/externs.orng
@@ -1,12 +1,6 @@
-extern const putchar: Byte -> Int32
-
-fn print(s: String) -> () {
-    while let mut i = 0; i < s.length; i += 1 {
-        _ = putchar(s[i])
-    }
-}
+import printfns
 
 fn println(s: String) -> () {
-    print(s)
-    print("\n")
+    printfns::print(s)
+    printfns::print("\n")
 }

--- a/examples/printfns.orng
+++ b/examples/printfns.orng
@@ -1,0 +1,9 @@
+import externs
+
+extern const putchar: Byte -> Int32
+
+fn print(s: String) -> () {
+    while let mut i = 0; i < s.length; i += 1 {
+        _ = putchar(s[i])
+    }
+}

--- a/src/ast/decorate-access.zig
+++ b/src/ast/decorate-access.zig
@@ -63,6 +63,8 @@ fn resolve_import_symbol(self: Self, ast: *ast_.AST) *Symbol {
     const local_module_lookup = self.compiler.lookup_module(other_module_dir);
     const foreign_module_lookup = self.compiler.lookup_package_root_module(curr_package_path, ast.symbol().?.kind.import.real_name);
 
+    // TODO: This doesn't work when we do:
+    //   import module::member
     return (local_module_lookup orelse foreign_module_lookup).?;
 }
 

--- a/src/ast/import.zig
+++ b/src/ast/import.zig
@@ -39,19 +39,12 @@ fn next_anon_name(class: []const u8, allocator: std.mem.Allocator) []const u8 {
     return (out.toOwned() catch unreachable).?;
 }
 
+/// Converts imports to constant declarations
 pub fn flat(self: Self, ast: *ast_.AST, asts: *std.ArrayList(*ast_.AST), idx: usize) walker_.Error!usize {
-    if (ast.* != .import) { // +1
-        return 0; // +1
+    if (ast.* != .import) {
+        return 0;
     }
 
-    // If the import is complex, split it up into a root import, and const decl's off of it
-    //   Remember: modules are _just_ named unit types!
-    //   So something like:
-    //     import a::b::c
-    //   would become:
-    //     import a as $anon_module_0
-    //     const $anon_module_1 = $anon_module_0::b
-    //     const c = $anon_module_1::c
     if (ast.import.pattern.* == .pattern_symbol and ast.import.pattern.pattern_symbol.kind == .import) {
         // Re-arrange to be a decl for the import
         const common = ast_.AST_Common{ ._token = ast.token(), ._type = null };
@@ -68,77 +61,104 @@ pub fn flat(self: Self, ast: *ast_.AST, asts: *std.ArrayList(*ast_.AST), idx: us
         _ = try self.resolve_import(ast.decl.pattern);
         return 0;
     } else if (ast.import.pattern.* == .access) {
-        // given lhms::a0::a1::rmhs
-        // ((lmhs::a0)::a1)::rmhs
-        // The lmhs should be turned into an anon import decl
-        // an.. are consts that are accesses of the previous, with anon names
-        // rmhs is a const access with the real name
-        var curr = ast.import.pattern;
-        var terms = std.ArrayList(*ast_.AST).init(self.compiler.allocator());
-        defer terms.deinit();
-
-        while (curr.* == .access) : (curr = curr.lhs()) {
-            terms.append(curr.rhs()) catch unreachable;
-        }
-        terms.append(curr) catch unreachable;
-
-        var anon_names = std.ArrayList([]const u8).init(self.compiler.allocator());
-        defer anon_names.deinit();
-
-        for (0.., terms.items) |i, term| {
-            anon_names.append(
-                if (i == 0) term.token().data else next_anon_name("anon", self.compiler.allocator()),
-            ) catch unreachable;
-        }
-
-        for (0.., terms.items) |i, term| {
-            if (i < terms.items.len - 1) {
-                // Insert `const rhs = lhs::rhs`
-                const init = ast_.AST.create_access(
-                    ast.token(),
-                    ast_.AST.create_identifier(Token.init_simple(anon_names.items[i + 1]), self.compiler.allocator()),
-                    terms.items[i],
-                    self.compiler.allocator(),
-                );
-                const const_decl = ast_.AST.create_decl(
-                    ast.import.pattern.token(),
-                    ast_.AST.create_pattern_symbol(
-                        ast.token(),
-                        .import_inner,
-                        anon_names.items[i],
-                        self.compiler.allocator(),
-                    ),
-                    ast_.AST.create_type_of(ast.token(), init, self.compiler.allocator()),
-                    init,
-                    false,
-                    self.compiler.allocator(),
-                );
-                asts.insert(idx, const_decl) catch unreachable;
-            } else {
-                const common = ast_.AST_Common{ ._token = ast.token(), ._type = null };
-                ast.* = ast_.AST{ .decl = .{
-                    .common = common,
-                    .symbols = std.ArrayList(*Symbol).init(self.compiler.allocator()),
-                    .pattern = ast_.AST.create_pattern_symbol(
-                        ast.token(),
-                        .{ .import = .{ .real_name = term.token().data } },
-                        anon_names.items[i],
-                        self.compiler.allocator(),
-                    ),
-                    .type = primitives_.type_type,
-                    .init = primitives_.unit_type,
-                    ._top_level = true,
-                    .is_alias = false,
-                    .prohibit_defaults = false,
-                } };
-                _ = try self.resolve_import(ast.decl.pattern);
-            }
-        }
-
-        return terms.items.len - 1;
+        return self.unwrap_access_imports(ast, asts, idx);
     }
 
     return 0;
+}
+
+/// Rewrites import access-sequences of the form:
+///   import aaa::bbb::ccc
+/// to:
+///   import aaa as anon0
+///   const anon1 = aaa::bbb
+///   const ccc = anon1::ccc
+fn unwrap_access_imports(self: Self, ast: *ast_.AST, asts: *std.ArrayList(*ast_.AST), idx: usize) !usize {
+    var terms = self.create_terms(ast);
+    defer terms.deinit();
+
+    var anon_names = self.create_anon_names(&terms);
+    defer anon_names.deinit();
+
+    for (0.., terms.items) |i, term| {
+        if (i < terms.items.len - 1) {
+            // Not the last term
+            // Insert `const rhs = lhs::rhs`
+            const init = ast_.AST.create_access(
+                ast.token(),
+                ast_.AST.create_identifier(Token.init_simple(anon_names.items[i + 1]), self.compiler.allocator()),
+                terms.items[i],
+                self.compiler.allocator(),
+            );
+            const const_decl = ast_.AST.create_decl(
+                ast.import.pattern.token(),
+                ast_.AST.create_pattern_symbol(
+                    ast.token(),
+                    .import_inner,
+                    anon_names.items[i],
+                    self.compiler.allocator(),
+                ),
+                ast_.AST.create_type_of(ast.token(), init, self.compiler.allocator()),
+                init,
+                false,
+                self.compiler.allocator(),
+            );
+            asts.insert(idx, const_decl) catch unreachable;
+        } else {
+            // The last term
+            const common = ast_.AST_Common{ ._token = ast.token(), ._type = null };
+            ast.* = ast_.AST{ .decl = .{
+                .common = common,
+                .symbols = std.ArrayList(*Symbol).init(self.compiler.allocator()),
+                .pattern = ast_.AST.create_pattern_symbol(
+                    ast.token(),
+                    .{ .import = .{ .real_name = term.token().data } },
+                    anon_names.items[i],
+                    self.compiler.allocator(),
+                ),
+                .type = primitives_.type_type,
+                .init = primitives_.unit_type,
+                ._top_level = true,
+                .is_alias = false,
+                .prohibit_defaults = false,
+            } };
+            _ = try self.resolve_import(ast.decl.pattern);
+        }
+    }
+
+    return terms.items.len - 1;
+}
+
+/// Creates a list of terms from an access-sequence in reverse order.
+/// Turns:
+///   aaa::bbb::ccc
+/// int:
+///   [ccc, bbb, aaa]
+fn create_terms(self: Self, ast: *ast_.AST) std.ArrayList(*ast_.AST) {
+    var curr = ast.import.pattern;
+    var terms = std.ArrayList(*ast_.AST).init(self.compiler.allocator());
+
+    while (curr.* == .access) : (curr = curr.lhs()) {
+        terms.append(curr.rhs()) catch unreachable;
+    }
+    terms.append(curr) catch unreachable;
+    return terms;
+}
+
+/// Creates a list of anonymous names to use when unwrapping an access-sequence import, where the first is the actual
+/// name, and every other is an anonymous name.
+/// Turns:
+///    aaa::bbb::ccc
+/// into:
+///    [ccc, anon0, anon1]
+fn create_anon_names(self: Self, terms: *std.ArrayList(*ast_.AST)) std.ArrayList([]const u8) {
+    var anon_names = std.ArrayList([]const u8).init(self.compiler.allocator());
+    for (0.., terms.items) |i, term| {
+        anon_names.append(
+            if (i == 0) term.token().data else next_anon_name("anon", self.compiler.allocator()),
+        ) catch unreachable;
+    }
+    return anon_names;
 }
 
 /// Given an import pattern symbol `ast`, resolve the module symbol that it refers to, potentially compiling it if

--- a/src/ast/import.zig
+++ b/src/ast/import.zig
@@ -40,100 +40,102 @@ fn next_anon_name(class: []const u8, allocator: std.mem.Allocator) []const u8 {
 }
 
 pub fn flat(self: Self, ast: *ast_.AST, asts: *std.ArrayList(*ast_.AST), idx: usize) walker_.Error!usize {
-    if (ast.* == .import) {
-        // If the import is complex, split it up into a root import, and const decl's off of it
-        //   Remember: modules are _just_ named unit types!
-        //   So something like:
-        //     import a::b::c
-        //   would become:
-        //     import a as $anon_module_0
-        //     const $anon_module_1 = $anon_module_0::b
-        //     const c = $anon_module_1::c
-        if (ast.import.pattern.* == .pattern_symbol and ast.import.pattern.pattern_symbol.kind == .import) {
-            // Re-arrange to be a decl for the import
-            const common = ast_.AST_Common{ ._token = ast.token(), ._type = null };
-            ast.* = ast_.AST{ .decl = .{
-                .common = common,
-                .symbols = std.ArrayList(*Symbol).init(self.compiler.allocator()),
-                .pattern = ast.import.pattern,
-                .type = primitives_.type_type,
-                .init = primitives_.unit_type,
-                ._top_level = true,
-                .is_alias = false,
-                .prohibit_defaults = false,
-            } };
-            _ = try self.resolve_import(ast.decl.pattern);
-            return 0;
-        } else if (ast.import.pattern.* == .access) {
-            // given lhms::a0::a1::rmhs
-            // ((lmhs::a0)::a1)::rmhs
-            // The lmhs should be turned into an anon import decl
-            // an.. are consts that are accesses of the previous, with anon names
-            // rmhs is a const access with the real name
-            var curr = ast.import.pattern;
-            var terms = std.ArrayList(*ast_.AST).init(self.compiler.allocator());
-            defer terms.deinit();
+    if (ast.* != .import) { // +1
+        return 0; // +1
+    }
 
-            while (curr.* == .access) : (curr = curr.lhs()) {
-                terms.append(curr.rhs()) catch unreachable;
-            }
-            terms.append(curr) catch unreachable;
+    // If the import is complex, split it up into a root import, and const decl's off of it
+    //   Remember: modules are _just_ named unit types!
+    //   So something like:
+    //     import a::b::c
+    //   would become:
+    //     import a as $anon_module_0
+    //     const $anon_module_1 = $anon_module_0::b
+    //     const c = $anon_module_1::c
+    if (ast.import.pattern.* == .pattern_symbol and ast.import.pattern.pattern_symbol.kind == .import) {
+        // Re-arrange to be a decl for the import
+        const common = ast_.AST_Common{ ._token = ast.token(), ._type = null };
+        ast.* = ast_.AST{ .decl = .{
+            .common = common,
+            .symbols = std.ArrayList(*Symbol).init(self.compiler.allocator()),
+            .pattern = ast.import.pattern,
+            .type = primitives_.type_type,
+            .init = primitives_.unit_type,
+            ._top_level = true,
+            .is_alias = false,
+            .prohibit_defaults = false,
+        } };
+        _ = try self.resolve_import(ast.decl.pattern);
+        return 0;
+    } else if (ast.import.pattern.* == .access) {
+        // given lhms::a0::a1::rmhs
+        // ((lmhs::a0)::a1)::rmhs
+        // The lmhs should be turned into an anon import decl
+        // an.. are consts that are accesses of the previous, with anon names
+        // rmhs is a const access with the real name
+        var curr = ast.import.pattern;
+        var terms = std.ArrayList(*ast_.AST).init(self.compiler.allocator());
+        defer terms.deinit();
 
-            var anon_names = std.ArrayList([]const u8).init(self.compiler.allocator());
-            defer anon_names.deinit();
-
-            for (0.., terms.items) |i, term| {
-                anon_names.append(
-                    if (i == 0) term.token().data else next_anon_name("anon", self.compiler.allocator()),
-                ) catch unreachable;
-            }
-
-            for (0.., terms.items) |i, term| {
-                if (i < terms.items.len - 1) {
-                    // Insert `const rhs = lhs::rhs`
-                    const init = ast_.AST.create_access(
-                        ast.token(),
-                        ast_.AST.create_identifier(Token.init_simple(anon_names.items[i + 1]), self.compiler.allocator()),
-                        terms.items[i],
-                        self.compiler.allocator(),
-                    );
-                    const const_decl = ast_.AST.create_decl(
-                        ast.import.pattern.token(),
-                        ast_.AST.create_pattern_symbol(
-                            ast.token(),
-                            .import_inner,
-                            anon_names.items[i],
-                            self.compiler.allocator(),
-                        ),
-                        ast_.AST.create_type_of(ast.token(), init, self.compiler.allocator()),
-                        init,
-                        false,
-                        self.compiler.allocator(),
-                    );
-                    asts.insert(idx, const_decl) catch unreachable;
-                } else {
-                    const common = ast_.AST_Common{ ._token = ast.token(), ._type = null };
-                    ast.* = ast_.AST{ .decl = .{
-                        .common = common,
-                        .symbols = std.ArrayList(*Symbol).init(self.compiler.allocator()),
-                        .pattern = ast_.AST.create_pattern_symbol(
-                            ast.token(),
-                            .{ .import = .{ .real_name = term.token().data } },
-                            anon_names.items[i],
-                            self.compiler.allocator(),
-                        ),
-                        .type = primitives_.type_type,
-                        .init = primitives_.unit_type,
-                        ._top_level = true,
-                        .is_alias = false,
-                        .prohibit_defaults = false,
-                    } };
-                    _ = try self.resolve_import(ast.decl.pattern);
-                }
-            }
-
-            return terms.items.len - 1;
+        while (curr.* == .access) : (curr = curr.lhs()) {
+            terms.append(curr.rhs()) catch unreachable;
         }
+        terms.append(curr) catch unreachable;
+
+        var anon_names = std.ArrayList([]const u8).init(self.compiler.allocator());
+        defer anon_names.deinit();
+
+        for (0.., terms.items) |i, term| {
+            anon_names.append(
+                if (i == 0) term.token().data else next_anon_name("anon", self.compiler.allocator()),
+            ) catch unreachable;
+        }
+
+        for (0.., terms.items) |i, term| {
+            if (i < terms.items.len - 1) {
+                // Insert `const rhs = lhs::rhs`
+                const init = ast_.AST.create_access(
+                    ast.token(),
+                    ast_.AST.create_identifier(Token.init_simple(anon_names.items[i + 1]), self.compiler.allocator()),
+                    terms.items[i],
+                    self.compiler.allocator(),
+                );
+                const const_decl = ast_.AST.create_decl(
+                    ast.import.pattern.token(),
+                    ast_.AST.create_pattern_symbol(
+                        ast.token(),
+                        .import_inner,
+                        anon_names.items[i],
+                        self.compiler.allocator(),
+                    ),
+                    ast_.AST.create_type_of(ast.token(), init, self.compiler.allocator()),
+                    init,
+                    false,
+                    self.compiler.allocator(),
+                );
+                asts.insert(idx, const_decl) catch unreachable;
+            } else {
+                const common = ast_.AST_Common{ ._token = ast.token(), ._type = null };
+                ast.* = ast_.AST{ .decl = .{
+                    .common = common,
+                    .symbols = std.ArrayList(*Symbol).init(self.compiler.allocator()),
+                    .pattern = ast_.AST.create_pattern_symbol(
+                        ast.token(),
+                        .{ .import = .{ .real_name = term.token().data } },
+                        anon_names.items[i],
+                        self.compiler.allocator(),
+                    ),
+                    .type = primitives_.type_type,
+                    .init = primitives_.unit_type,
+                    ._top_level = true,
+                    .is_alias = false,
+                    .prohibit_defaults = false,
+                } };
+                _ = try self.resolve_import(ast.decl.pattern);
+            }
+        }
+
+        return terms.items.len - 1;
     }
 
     return 0;

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -24,7 +24,9 @@ pub fn output_modules(compiler: *Compiler_Context) !void {
         var dfs_iter: Module_Iterator = Module_Iterator.init(package_root_module, compiler.allocator());
         defer dfs_iter.deinit();
         while (dfs_iter.next()) |module| {
-            try output(module, &compiler.module_interned_strings, build_path, compiler.allocator());
+            if (std.mem.eql(u8, module.get_package_abs_path(), package.absolute_path)) {
+                try output(module, &compiler.module_interned_strings, build_path, compiler.allocator());
+            }
         }
     }
 }

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -14,9 +14,7 @@ pub fn output_modules(compiler: *Compiler_Context) !void {
         const package = compiler.lookup_package(package_name).?;
         const package_root_module = package.root.init_value.?.module.module;
 
-        const package_path = package_root_module.get_package_abs_path();
-        const build_paths = [_][]const u8{ package_path, "build" };
-        const build_path = std.fs.path.join(compiler.allocator(), &build_paths) catch unreachable;
+        const build_path = package.get_build_path(compiler.allocator());
         _ = std.fs.openDirAbsolute(build_path, .{}) catch {
             std.fs.makeDirAbsolute(build_path) catch unreachable;
         };

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -12,19 +12,19 @@ pub fn output_modules(compiler: *Compiler_Context) !void {
     // Start from root module, of each package, DFS through imports and generate
     for (compiler.packages.keys()) |package_name| {
         const package = compiler.lookup_package(package_name).?;
-        const module = package.root.init_value.?.module.module;
+        const package_root_module = package.root.init_value.?.module.module;
 
-        const package_path = module.get_package_abs_path();
+        const package_path = package_root_module.get_package_abs_path();
         const build_paths = [_][]const u8{ package_path, "build" };
         const build_path = std.fs.path.join(compiler.allocator(), &build_paths) catch unreachable;
         _ = std.fs.openDirAbsolute(build_path, .{}) catch {
             std.fs.makeDirAbsolute(build_path) catch unreachable;
         };
 
-        var dfs_iter: Module_Iterator = Module_Iterator.init(module, compiler.allocator());
+        var dfs_iter: Module_Iterator = Module_Iterator.init(package_root_module, compiler.allocator());
         defer dfs_iter.deinit();
-        while (dfs_iter.next()) |next_module| {
-            try output(next_module, &compiler.module_interned_strings, build_path, &package.local_modules, compiler.allocator());
+        while (dfs_iter.next()) |module| {
+            try output(module, &compiler.module_interned_strings, build_path, compiler.allocator());
         }
     }
 }
@@ -34,11 +34,8 @@ fn output(
     module: *Module,
     module_interned_strings: *const std.AutoArrayHashMap(u32, *Interned_String_Set),
     build_path: []const u8,
-    local_modules: *std.ArrayList(*Module),
     allocator: std.mem.Allocator,
 ) !void {
-    local_modules.append(module) catch unreachable;
-
     var output_h_filename = String.init(allocator);
     defer output_h_filename.deinit();
     output_h_filename.writer().print("{s}-{s}.h", .{ module.package_name, module.name() }) catch unreachable;
@@ -58,10 +55,4 @@ fn output(
     defer output_c_file.close();
     var source_emitter = Source_Emitter.init(module, module_interned_strings, output_c_file.writer());
     source_emitter.generate() catch return error.CompileError;
-
-    for (module.local_imported_modules.keys()) |child| {
-        if (std.mem.eql(u8, child.package_name, module.package_name)) {
-            try output(child, module_interned_strings, build_path, local_modules, allocator);
-        }
-    }
 }

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -17,8 +17,9 @@ pub fn output_modules(compiler: *Compiler_Context) !void {
         const package_path = module.get_package_abs_path();
         const build_paths = [_][]const u8{ package_path, "build" };
         const build_path = std.fs.path.join(compiler.allocator(), &build_paths) catch unreachable;
-        std.fs.deleteTreeAbsolute(build_path) catch unreachable;
-        std.fs.makeDirAbsolute(build_path) catch unreachable;
+        _ = std.fs.openDirAbsolute(build_path, .{}) catch {
+            std.fs.makeDirAbsolute(build_path) catch unreachable;
+        };
 
         var dfs_iter: Module_Iterator = Module_Iterator.init(module, compiler.allocator());
         defer dfs_iter.deinit();
@@ -29,7 +30,13 @@ pub fn output_modules(compiler: *Compiler_Context) !void {
 }
 
 /// Takes in a statically correct symbol tree, writes it out to a file
-fn output(module: *Module, module_interned_strings: *const std.AutoArrayHashMap(u32, *Interned_String_Set), build_path: []const u8, local_modules: *std.ArrayList(*Module), allocator: std.mem.Allocator) !void {
+fn output(
+    module: *Module,
+    module_interned_strings: *const std.AutoArrayHashMap(u32, *Interned_String_Set),
+    build_path: []const u8,
+    local_modules: *std.ArrayList(*Module),
+    allocator: std.mem.Allocator,
+) !void {
     local_modules.append(module) catch unreachable;
 
     var output_h_filename = String.init(allocator);

--- a/src/hierarchy/compiler.zig
+++ b/src/hierarchy/compiler.zig
@@ -110,6 +110,10 @@ pub fn lookup_module(self: *Self, absolute_path: []const u8) ?*Symbol {
     return self.modules.get(absolute_path);
 }
 
+pub fn register_module(self: *Self, absolute_path: []const u8, module: *Symbol) void {
+    self.modules.put(absolute_path, module) catch unreachable;
+}
+
 pub fn module_scope(self: *Self, absolute_path: []const u8) ?*Scope {
     const module_symbol = self.lookup_module(absolute_path) orelse return null;
     return module_symbol.init_value.?.scope();
@@ -188,9 +192,9 @@ pub fn collect_package_local_modules(self: *Self) void {
     }
 }
 
-pub fn determine_if_modified(self: *Self, root_package_absolute_path: []const u8) void {
+pub fn determine_if_modified(self: *Self, root_package_absolute_path: []const u8) !void {
     const package = self.lookup_package(root_package_absolute_path).?;
-    package.determine_if_modified(self.packages, self);
+    try package.determine_if_modified(self.packages, self);
 }
 
 pub fn compile(self: *Self, root_package_absolute_path: []const u8, extra_flags: bool) !void {

--- a/src/hierarchy/compiler.zig
+++ b/src/hierarchy/compiler.zig
@@ -81,7 +81,6 @@ pub fn compile_module(
         return module;
     }
 
-    std.debug.print("  compiling {s}/{s}...\n", .{ std.fs.path.basename(std.fs.path.dirname(absolute_path).?), std.fs.path.basename(absolute_path) });
     const module = Module.compile(absolute_path, entry_name, fuzz_tokens, self) catch |err| {
         switch (err) {
             // Always print these errors for fuzz testing

--- a/src/hierarchy/module_hash.zig
+++ b/src/hierarchy/module_hash.zig
@@ -2,22 +2,34 @@ const std = @import("std");
 
 const Self = @This();
 
-json_module_hash_map: ?std.json.Value,
+json_parsed: ?std.json.Parsed(std.json.Value),
 json_absolute_path: []const u8,
 
+/// Attempts to open up the hash.json file if it exists, and reads in the json data. If the file doesn't exist, simply
+/// sets the json data to null to be filled in later.
+///
+/// Potentially allocates for json data. Call deinit to deinitialize.
 pub fn init(package_absolute_path: []const u8, allocator: std.mem.Allocator) !Self {
     const json_absolute_paths = [_][]const u8{ package_absolute_path, "build", "hash.json" };
     const json_absolute_path = std.fs.path.join(allocator, &json_absolute_paths) catch unreachable;
+
     const contents = read_contents(json_absolute_path, allocator) catch |err| switch (err) {
-        error.FileNotFound => return Self{ .json_module_hash_map = null, .json_absolute_path = json_absolute_path },
+        error.FileNotFound => return Self{ .json_parsed = null, .json_absolute_path = json_absolute_path },
         else => return error.CompileError,
     };
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, contents, .{}) catch
-        return Self{ .json_module_hash_map = null, .json_absolute_path = json_absolute_path };
+        return Self{ .json_parsed = null, .json_absolute_path = json_absolute_path };
     return Self{
-        .json_module_hash_map = parsed.value,
+        .json_parsed = parsed,
         .json_absolute_path = json_absolute_path,
     };
+}
+
+/// Deinitializes a module hash struct
+pub fn deinit(self: *Self) void {
+    if (self.json_parsed) |parsed| {
+        parsed.deinit();
+    }
 }
 
 fn read_contents(absolute_path: []const u8, allocator: std.mem.Allocator) ![]const u8 {
@@ -42,9 +54,9 @@ fn read_contents(absolute_path: []const u8, allocator: std.mem.Allocator) ![]con
     return contents;
 }
 
-pub fn get_module_stored_hash(self: *Self, module_name: []const u8) ?[]const u8 {
-    if (self.json_module_hash_map) |old_json_map| {
-        const module_lookup_res = old_json_map.object.get(module_name) orelse return null;
+pub fn get_module_stored_hash(self: *const Self, module_name: []const u8) ?[]const u8 {
+    if (self.json_parsed) |old_json_parsed| {
+        const module_lookup_res = old_json_parsed.value.object.get(module_name) orelse return null;
         return module_lookup_res.string;
     } else {
         return null;
@@ -52,16 +64,18 @@ pub fn get_module_stored_hash(self: *Self, module_name: []const u8) ?[]const u8 
 }
 
 pub fn set_module_hash(self: *Self, module_name: []const u8, hash_number_string: []const u8, allocator: std.mem.Allocator) !void {
-    if (self.json_module_hash_map == null) {
-        self.json_module_hash_map = (std.json.parseFromSlice(std.json.Value, allocator, "{}", .{}) catch unreachable).value;
+    if (self.json_parsed == null) {
+        self.json_parsed = std.json.parseFromSlice(std.json.Value, allocator, "{}", .{}) catch unreachable;
     }
-
-    self.json_module_hash_map.?.object.put(module_name, std.json.Value{ .string = hash_number_string }) catch unreachable;
+    self.json_parsed.?.value.object.put(module_name, std.json.Value{ .string = hash_number_string }) catch unreachable;
 }
 
-pub fn output_new_json(self: *Self) void {
+pub fn output_new_json(self: *Self, allocator: std.mem.Allocator) void {
+    if (self.json_parsed == null) {
+        self.json_parsed = std.json.parseFromSlice(std.json.Value, allocator, "{}", .{}) catch unreachable;
+    }
     var json_file_handle = std.fs.createFileAbsolute(self.json_absolute_path, .{}) catch unreachable;
     defer json_file_handle.close();
     const writer = json_file_handle.writer();
-    std.json.stringify(self.json_module_hash_map.?, .{}, writer) catch unreachable;
+    std.json.stringify(self.json_parsed.?.value, .{}, writer) catch unreachable;
 }

--- a/src/hierarchy/module_hash.zig
+++ b/src/hierarchy/module_hash.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+
+const Self = @This();
+
+json_module_hash_map: ?std.json.Value,
+json_absolute_path: []const u8,
+
+pub fn init(package_absolute_path: []const u8, allocator: std.mem.Allocator) !Self {
+    const json_absolute_paths = [_][]const u8{ package_absolute_path, "build", "hash.json" };
+    const json_absolute_path = std.fs.path.join(allocator, &json_absolute_paths) catch unreachable;
+    const contents = read_contents(json_absolute_path, allocator) catch |err| switch (err) {
+        error.FileNotFound => return Self{ .json_module_hash_map = null, .json_absolute_path = json_absolute_path },
+        else => return error.CompileError,
+    };
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, contents, .{}) catch
+        return Self{ .json_module_hash_map = null, .json_absolute_path = json_absolute_path };
+    return Self{
+        .json_module_hash_map = parsed.value,
+        .json_absolute_path = json_absolute_path,
+    };
+}
+
+fn read_contents(absolute_path: []const u8, allocator: std.mem.Allocator) ![]const u8 {
+    var file = std.fs.openFileAbsolute(absolute_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return error.FileNotFound,
+        else => return error.CompileError,
+    };
+    defer file.close();
+
+    const stat = file.stat() catch return error.CompileError;
+    const uid = stat.mtime;
+    _ = uid;
+
+    // Read in the contents of the file
+    var buf_reader = std.io.bufferedReader(file.reader());
+    var in_stream = buf_reader.reader();
+    var contents_arraylist = std.ArrayList(u8).init(allocator);
+    defer contents_arraylist.deinit();
+    in_stream.readAllArrayList(&contents_arraylist, 0xFFFF_FFFF) catch unreachable;
+    const contents = contents_arraylist.toOwnedSlice() catch unreachable;
+
+    return contents;
+}
+
+pub fn get_module_stored_hash(self: *Self, module_name: []const u8) ?[]const u8 {
+    if (self.json_module_hash_map) |old_json_map| {
+        const module_lookup_res = old_json_map.object.get(module_name) orelse return null;
+        return module_lookup_res.string;
+    } else {
+        return null;
+    }
+}
+
+pub fn set_module_hash(self: *Self, module_name: []const u8, hash_number_string: []const u8, allocator: std.mem.Allocator) !void {
+    if (self.json_module_hash_map == null) {
+        self.json_module_hash_map = (std.json.parseFromSlice(std.json.Value, allocator, "{}", .{}) catch unreachable).value;
+    }
+
+    self.json_module_hash_map.?.object.put(module_name, std.json.Value{ .string = hash_number_string }) catch unreachable;
+}
+
+pub fn output_new_json(self: *Self) void {
+    var json_file_handle = std.fs.createFileAbsolute(self.json_absolute_path, .{}) catch unreachable;
+    defer json_file_handle.close();
+    const writer = json_file_handle.writer();
+    std.json.stringify(self.json_module_hash_map.?, .{}, writer) catch unreachable;
+}

--- a/src/lexer/hash.zig
+++ b/src/lexer/hash.zig
@@ -1,0 +1,18 @@
+//! This file is responsible for calculating the hash of a module, to track changes
+
+const std = @import("std");
+
+const Self = @This();
+
+module_contents_hash: *u64,
+
+pub fn init(module_contents_hash: *u64) Self {
+    return Self{
+        .module_contents_hash = module_contents_hash,
+    };
+}
+
+pub fn run(self: *Self, contents: []const u8) error{}![]const u8 {
+    self.module_contents_hash.* = std.hash.XxHash3.hash(0, contents);
+    return contents;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -76,7 +76,7 @@ fn build(name: []const u8, args: *std.process.ArgIterator, allocator: std.mem.Al
     const package_abs_path = try construct_package_dag(compiler);
     compiler.propagate_include_directories(package_abs_path);
     compiler.collect_package_local_modules();
-    compiler.determine_if_modified(package_abs_path);
+    try compiler.determine_if_modified(package_abs_path);
     try Codegen_Context.output_modules(compiler);
     try compiler.compile(package_abs_path, false);
 
@@ -356,9 +356,8 @@ fn clean(name: []const u8, args: *std.process.ArgIterator, allocator: std.mem.Al
 fn construct_package_dag(compiler: *Compiler_Context) Command_Error![]const u8 {
     // try validate_env_vars(allocator);
     const build_path_buffer = std.heap.page_allocator.alloc(u8, std.fs.max_path_bytes) catch unreachable;
-    defer std.heap.page_allocator.free(build_path_buffer);
 
-    const build_path = std.fs.cwd().realpath("build.orng", build_path_buffer) catch |err| switch (err) {
+    const build_path: []const u8 = std.fs.cwd().realpath("build.orng", build_path_buffer) catch |err| switch (err) {
         error.FileNotFound => {
             (errs_.Error{ .basic = .{
                 .msg = "no `build.orng` file found in current working directory",

--- a/src/main.zig
+++ b/src/main.zig
@@ -95,9 +95,10 @@ fn build(name: []const u8, args: *std.process.ArgIterator, allocator: std.mem.Al
     const package_abs_path = std.fs.cwd().realpath(".", cwd_buffer) catch unreachable;
     _ = try make_package(package_dag, compiler, &interpreter, package_abs_path, "main");
 
-    try Codegen_Context.output_modules(compiler);
-
     compiler.propagate_include_directories(package_abs_path);
+    compiler.collect_package_local_modules();
+    compiler.determine_if_modified(package_abs_path);
+    try Codegen_Context.output_modules(compiler);
     try compiler.compile(package_abs_path, false);
 
     std.debug.print("done\n", .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -67,7 +67,7 @@ pub fn main() !void {
 }
 
 fn build(name: []const u8, args: *std.process.ArgIterator, allocator: std.mem.Allocator) Command_Error!void {
-    try validate_env_vars(allocator);
+    // try validate_env_vars(allocator);
 
     _ = args;
     // Get the path

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,7 +10,7 @@ const String = @import("zig-string/zig-string.zig").String;
 const Symbol = @import("symbol/symbol.zig");
 
 const version_year: usize = 25;
-const version_month: usize = 1;
+const version_month: usize = 3;
 const version_minor: ?usize = null;
 
 pub const Command_Error: type = error{ LexerError, ParseError, CompileError, FileError, FileNotFound };
@@ -26,6 +26,7 @@ const Command_Entry: type = struct {
 // Keep these in alphabetical order
 const command_table = [_]Command_Entry{
     Command_Entry{ .name = "build", .help = "Builds an Orng package", .func = build },
+    Command_Entry{ .name = "clean", .help = "Clears the build cache, and forces a complete rebuild of the Orng package", .func = clean },
     Command_Entry{ .name = "_fuzz_tokens", .help = "Builds an Orng package with fuzz tokens", .func = build },
     Command_Entry{ .name = "help", .help = "Prints this help menu", .func = help },
     Command_Entry{ .name = "init", .help = "Creates two files, one containing a sample Hello World program and a file to allow for it to be built", .func = init_project },
@@ -353,4 +354,12 @@ pub fn init_project(name: []const u8, args: *std.process.ArgIterator, allocator:
         \\}
     ;
     build_orng.writer().writeAll(build_content) catch return error.FileError;
+}
+
+fn clean(name: []const u8, args: *std.process.ArgIterator, allocator: std.mem.Allocator) Command_Error!void {
+    _ = name;
+    _ = args;
+    _ = allocator;
+
+    // TODO: Find the package's `build/` and just delete it
 }

--- a/src/util/dfs.zig
+++ b/src/util/dfs.zig
@@ -38,6 +38,14 @@ pub fn Dfs_Iterator(comptime T: type) type {
                 }
             }
 
+            // If the type allows us to free the adjacency slice, free it.
+            if (@typeInfo(T) == .@"struct" and @hasDecl(T, "free_adjacent")) {
+                self.current.?.free_adjacent(adjacent);
+                // Side note: this sucks! If only zig had traits!
+            } else if (@typeInfo(T) == .pointer and @typeInfo(@typeInfo(T).pointer.child) == .@"struct" and @hasDecl(@typeInfo(T).pointer.child, "free_adjacent")) {
+                self.current.?.free_adjacent(adjacent);
+            }
+
             // Advance to the next value
             self.current = null;
             while (self.stack.pop()) |next_val| {

--- a/src/util/dfs.zig
+++ b/src/util/dfs.zig
@@ -5,28 +5,12 @@ pub fn Dfs_Iterator(comptime T: type) type {
         const Self = @This();
         current: ?T,
 
-        backlog: ?[]T,
-        backlog_idx: usize,
-
         stack: std.ArrayList(T),
         visited: std.AutoHashMap(T, void),
 
         pub fn init(start: T, allocator: std.mem.Allocator) Self {
             return Self{
                 .current = start,
-                .backlog = null,
-                .backlog_idx = 0,
-                .stack = std.ArrayList(T).init(allocator),
-                .visited = std.AutoHashMap(T, void).init(allocator),
-            };
-        }
-
-        pub fn init_many(starts: []T, allocator: std.mem.Allocator) Self {
-            std.debug.assert(starts.len > 0);
-            return Self{
-                .current = starts[0],
-                .backlog = starts,
-                .backlog_idx = 0,
                 .stack = std.ArrayList(T).init(allocator),
                 .visited = std.AutoHashMap(T, void).init(allocator),
             };
@@ -49,7 +33,7 @@ pub fn Dfs_Iterator(comptime T: type) type {
             // We do a visited check here to avoid revisiting vertices
             const adjacent: []T = self.current.?.get_adjacent();
             for (adjacent) |target| {
-                if (self.visited.contains(target)) {
+                if (!self.visited.contains(target)) {
                     self.stack.append(target) catch unreachable;
                 }
             }
@@ -60,17 +44,6 @@ pub fn Dfs_Iterator(comptime T: type) type {
                 if (!self.visited.contains(next_val)) {
                     self.current = next_val;
                     break;
-                }
-            }
-
-            // If still null, advance backlog
-            if (self.backlog) |backlog| {
-                while (self.backlog_idx < backlog.len) : (self.backlog_idx += 1) {
-                    const backlog_val = backlog[self.backlog_idx];
-                    if (!self.visited.contains(backlog_val)) {
-                        self.current = backlog_val;
-                        break;
-                    }
                 }
             }
 

--- a/src/util/pipeline.zig
+++ b/src/util/pipeline.zig
@@ -27,6 +27,9 @@ fn run_inner(previous_value: anytype, pipeline: anytype, comptime step_index: us
     var step = @field(pipeline, field.name);
 
     // Run the step on the previous value
+    if (!@hasDecl(@TypeOf(step), "run")) {
+        @compileError(std.fmt.comptimePrint("the step `{}` does not have a public run() method!", .{@TypeOf(step)}));
+    }
     const run_result = try step.run(previous_value);
 
     if (step_index + 1 == fields.len) {

--- a/src/util/repo.zig
+++ b/src/util/repo.zig
@@ -7,9 +7,11 @@ pub fn git_clone(repo_url: []const u8, allocator: std.mem.Allocator) Error!void 
     ensure_packages_dir_exists(allocator);
 
     if (repo_exists(repo_url, allocator)) {
-        std.debug.print("{s} already exists\n", .{repo_url});
         return;
     }
+
+    const cwd = get_packages_dir(allocator);
+    std.debug.print("cloning package `{s}`\n", .{repo_url});
 
     var cmd = std.ArrayList([]const u8).init(allocator);
     cmd.appendSlice(&[_][]const u8{
@@ -22,7 +24,7 @@ pub fn git_clone(repo_url: []const u8, allocator: std.mem.Allocator) Error!void 
     const run_res = std.process.Child.run(.{
         .allocator = allocator,
         .argv = cmd.items,
-        .cwd = get_packages_dir(allocator),
+        .cwd = cwd,
     }) catch unreachable;
 
     var retcode: u8 = 0;

--- a/tests/static_analysis/cognitive_complexity.py
+++ b/tests/static_analysis/cognitive_complexity.py
@@ -55,7 +55,6 @@ control_flow_tokens = [
     "or",
     "and",
     "orelse",
-    "try",
     "break",
     "continue",
     "return",


### PR DESCRIPTION
This PR makes it so that the compiler will only re-generate and re-compile the C files when a module's hash has changed or one of its dependencies has changed, and will only re-link packages when a package has changed or one of its dependencies has changed. Also added an `orng clean`, which clears the cache for the package.