### PR TITLE
Add error message checks for negative tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Orng is a versatile systems programming language I've been developing that gives
 * Tutorials can be found [here (coming soon)](http://ornglang.orng/tutorials).
 * Documentation can be found [here (coming soon)](http://ornglang.orng/docs).
 
-## 🚀 Quick Start
+## Quick Start
 ```sh
 # Orng compiler requires Zig 0.13.0 at the moment
 git clone --recursive https://github.com/Rakhyvel/Orng.git
@@ -47,12 +47,11 @@ Run it with:
 orng run
 ```
 
-## ✨ Standout Features
+## Standout Features
 Orng comes with a wide range of features that make it a powerful and flexible programming language, including:
 
 ### First-Class Types
-In Orng, types are first class citizens. Pass types as function arguments, return them from functions, and create powerful generic abstractions.
-
+In Orng, types are values. You can pass them to functions, return them, match on them, and construct them programmatically.
 ```rs
 fn make_array_type(const n: Int, const T: Type) -> Type { [n]T }
 
@@ -63,22 +62,47 @@ fn main() {
 ```
 [More examples](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/generics)
 
-### Parametric Effect System
-Say goodbye to hidden side effects! Orng forbids global variables and requires all objects to be explicitly passed as parameters, making your program's behavior transparent and predictable.
+### Pattern Matching & Destructuring
+Pattern matching in Orng lets you elagantly deconstruct complex data structures with a single, readable expression. Forget verbose `if-else` chains and nested conditionals - match on ADTs, extract values, and handle different cases with unprecedented clarity.
 
 ```rs
-// We can tell this function doesn't do anything dangerous
-fn something_harmless(x: T) { /* ... */ }
+const Person = (name: String, age: Int, job: String)
 
-// We can tell this function probably mutates it's arguments
-fn maybe_mutate(x: &mut T) { /* ... */ }
-
-// We can tell this function probably allocates memory
-fn maybe_alloc(alloc: impl Allocator) { /* ... */ }
-
-// We can tell this function probably does stuff with IO
-fn maybe_write(reader: impl Reader, writer: impl Writer) { /* ... */ }
+fn classify_person(person: Person) -> String {
+   match person {
+       (name, age, "Teacher") if age > 50 => "Veteran Educator"
+       (name, _,   "Doctor")              => "Medical professional"
+       (_,    age, _)         if age < 18 => "Baby 👶"
+   }
+}
 ```
+
+[More examples](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/pattern)
+
+### Algebraic Data Types
+Algebraic Data Types (ADTs) allow you to define types that can be one of several variants with zero runtime overhead. Represent complex state machines, parse abstract syntax trees, or handle error conditons with a single, compact type definition.
+
+```rs
+const Shape = (
+    | circle: (radius: Float)
+    | rectangle: (width: Float, height: Float)
+    | triangle: (base: Float, height: Float))
+
+fn calculate_area(shape: Shape) -> Float {
+    match shape {
+        .circle(r)         => 3.14 * r * r
+        .rectangle(w, h)   => w * h
+        .triangle(b, h)    => 0.5 * b * h
+    }
+}
+```
+
+[More](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/sums) [examples](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/tuples)
+
+### Seamless C Interoperability
+Compile to C and parse C header files with ease. Orng bridges the gap between low-level system programming and high-level expressiveness.
+
+[More examples](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/build)
 
 ### Traits 
 Traits offer a flexible way to define behavior that can be attatched to any type. Instead of deep inheritance hierarchies, Orng lets you extend types with new capabilities through simple composable traits.
@@ -108,51 +132,77 @@ fn main(sys: System) -> !() {
 }
 ```
 
-[More examples](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/traits)
-
-### Algebraic Data Types
-Algebraic Data Types (ADTs) allow you to define types that can be one of several variants with zero runtime overhead. Represent complex state machines, parse abstract syntax trees, or handle error conditons with a single, compact type definition.
-
+<!--
+### Higher-Kinded Types
+Orng supports higher-kinded types, natively.
 ```rs
-const Shape = (
-    | circle: (radius: Float)
-    | rectangle: (width: Float, height: Float)
-    | triangle: (base: Float, height: Float))
+fn Vec(const n: Int, const T: Type) -> Type {
+    [n]T
+}
 
-fn calculate_area(shape: Shape) -> Float {
-    match shape {
-        .circle(r)         => 3.14 * r * r
-        .rectangle(w, h)   => w * h
-        .triangle(b, h)    => 0.5 * b * h
+// Implement add for Vec of any length of any type that also implements Add
+impl Add for Vec($n, $T impl Add) {
+    const Output: Type = Self
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut retval: Vec(n, T) = undefiend
+        inline for i in 0..n {
+            retval[i] = self[i] + rhs[i]
+        }
+        retval
+    }
+}
+
+impl Functor for Option($T) {
+    fn fmap(self: Option(T), f: T -> $U) -> 
+}
+
+test "using + for vecs" {
+    let v: Vec(3, Int) = (1, 2, 4)
+    let u: Vec(3, Int) = (4, 4, 4)
+
+    let w = u + v
+
+    testing::expect(w == (5, 6, 8))
+}
+```
+
+### Universal and Existential Quantifiers
+The universal quantifier allows you to make assertions about all elements in a product or sum type. This is helpful for generic variadics.
+```rs
+trait Display {
+    fn display(&self, writer: &mut dyn Writer)
+}
+
+fn print(const fmt: String, args: (_, ...))
+where 
+  // all args must be display type
+  forall A in @Typeof(args) { A <: Display }
+{
+    let writer = // ...
+    inline for arg in args {
+        // Passes type check, since all arg in args implement Display
+        arg.>display(writer)
     }
 }
 ```
 
-[More](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/sums) [examples](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/tuples)
-
-### Pattern Matching & Destructuring
-Pattern matching in Orng lets you elagantly deconstruct complex data structures with a single, readable expression. Forget verbose `if-else` chains and nested conditionals - match on ADTs, extract values, and handle different cases with unprecedented clarity.
-
+The existential quantifier is useful for simulating row-polymorphism.
 ```rs
-const Person = (name: String, age: Int, job: String)
-
-fn classify_person(person: Person) -> String {
-   match person {
-       (name, age, "Teacher") if age > 50 => "Veteran Educator"
-       (name, _,   "Doctor")                => "Medical professional"
-       (_,    age, _)         if age < 18 => "Baby 👶"
-   }
+fn greet(person: (_, ...), out: &mut dyn Writer) 
+where
+  // There is a field in the product type of `person` called name of type String
+  exists T in @typeof(person) { T == (name: String) }
+{
+    // Passes type check, since there is gauranteed to be a field `name` in person
+    Writer::print(out, "Hello, {s}!", person.name)
 }
 ```
+-->
 
-[More examples](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/pattern)
+[More examples](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/traits)
 
-### Seamless C Interoperability
-Compile to C and parse C header files with ease. Orng bridges the gap between low-level system programming and high-level expressiveness.
-
-[More examples](https://github.com/Rakhyvel/Orng/blob/main/tests/integration/build)
-
-## 🤝 Get Involved
+## How to Contribute
 
 Contributions of all kinds are welcome:
 - 🐛 Report bugs
@@ -162,5 +212,5 @@ Contributions of all kinds are welcome:
 
 Check out [CONTRIBUTING.md](https://github.com/Rakhyvel/Orng/blob/main/CONTRIBUTING.md) for more info!
 
-## 📄 License
+## License
 Orng is open-source and released under the MIT License. See `LICENSE` for details.

--- a/src/ast/symbol-tree.zig
+++ b/src/ast/symbol-tree.zig
@@ -105,7 +105,7 @@ pub fn prefix(self: Self, ast: *ast_.AST) walk_.Error!?Self {
                     self.errors.add_error(
                         errs_.Error{
                             .basic = .{
-                                .msg = "anonymous functions specified with const parameters", // TODOL Could use some better wording
+                                .msg = "anonymous functions specified with const parameters", // TODO: Could use some better wording
                                 .span = ast.token().span,
                             },
                         },

--- a/src/hierarchy/compiler.zig
+++ b/src/hierarchy/compiler.zig
@@ -49,7 +49,7 @@ pub fn init(alloc: std.mem.Allocator) Error!*Self {
     retval.packages = std.StringArrayHashMap(*Package).init(retval.allocator());
     retval.prelude = primitives_.get_scope(retval) catch {
         // Prelude compilation can sometimes fail :(
-        retval.errors.print_errors();
+        retval.errors.print_errors(errs_.get_std_err(), .{});
         return error.CompileError;
     };
 
@@ -88,14 +88,14 @@ pub fn compile_module(
             error.ParseError,
             error.FileNotFound,
             => {
-                self.errors.print_errors();
+                self.errors.print_errors(errs_.get_std_err(), .{});
                 return err;
             },
 
             // Only print these errors if NOT fuzz testing
             error.CompileError,
             => if (!fuzz_tokens) {
-                self.errors.print_errors();
+                self.errors.print_errors(errs_.get_std_err(), .{});
                 return err;
             } else {
                 return err;

--- a/src/hierarchy/module.zig
+++ b/src/hierarchy/module.zig
@@ -106,6 +106,7 @@ pub const Module = struct {
         retval.type_set = Type_Set.init(allocator);
         retval.entry = null;
         retval.modified = null;
+
         return retval;
     }
 

--- a/src/hierarchy/primitives.zig
+++ b/src/hierarchy/primitives.zig
@@ -379,7 +379,7 @@ fn create_prelude(compiler: *Compiler_Context) !void {
 
     var errors = errs_.Errors.init(compiler.allocator());
     defer errors.deinit();
-    errdefer errors.print_errors();
+    errdefer errors.print_errors(errs_.get_std_err(), .{});
 
     var prelude_abs_path = String.init_with_contents(compiler.allocator(), "/prelude") catch unreachable;
     prelude_abs_path.writer().print("{c}prelude.orng", .{std.fs.path.sep}) catch unreachable;

--- a/src/interpretation/interpreter.zig
+++ b/src/interpretation/interpreter.zig
@@ -20,7 +20,7 @@ const Self = @This();
 const Error = error{CompileError};
 
 /// Interpreter execution timeout in milliseconds
-const timeout_ms = 10_000;
+const timeout_ms = 5_000;
 /// Size of the stack. 32 KiB, or around 1024 stack frames.
 const stack_limit = 0x8000; // 32 KiB
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -101,7 +101,7 @@ fn run(compiler: *Compiler_Context, package_abs_path: []const u8, allocator: std
         (errs_.Error{ .basic = .{
             .msg = "cannot run a non-executable package",
             .span = Span.phony,
-        } }).fatal_error();
+        } }).fatal_error(errs_.get_std_err(), .{});
         return error.CompileError;
     }
 
@@ -291,7 +291,7 @@ pub fn init_project(name: []const u8, args: *std.process.ArgIterator, allocator:
         (errs_.Error{ .basic = .{
             .msg = "an Orng package already exists here",
             .span = Span.phony,
-        } }).fatal_error();
+        } }).fatal_error(errs_.get_std_err(), .{});
     } else |err| switch (err) {
         error.FileNotFound => {},
         else => return error.FileError,
@@ -302,7 +302,7 @@ pub fn init_project(name: []const u8, args: *std.process.ArgIterator, allocator:
         (errs_.Error{ .basic = .{
             .msg = "an Orng package already exists here",
             .span = Span.phony,
-        } }).fatal_error();
+        } }).fatal_error(errs_.get_std_err(), .{});
     } else |err| switch (err) {
         error.FileNotFound => {},
         else => return error.FileError,
@@ -362,7 +362,7 @@ fn construct_package_dag(compiler: *Compiler_Context) Command_Error![]const u8 {
             (errs_.Error{ .basic = .{
                 .msg = "no `build.orng` file found in current working directory",
                 .span = Span.phony,
-            } }).fatal_error();
+            } }).fatal_error(errs_.get_std_err(), .{});
         },
         else => return error.CompileError,
     };

--- a/src/test.zig
+++ b/src/test.zig
@@ -200,20 +200,18 @@ fn negative_test_file(filename: []const u8, mode: Test_Mode, debug_alloc: *Debug
 
     var error_string = String.init(debug_alloc.allocator());
     defer error_string.deinit();
-    defer {
-        if (mode == .bless) {
-            bless_file("tests/test_bless.orng", error_string.str(), body) catch unreachable;
-        }
-    }
 
     // Try to compile Orng (make sure YES errors)
     _ = module_.Module.compile(absolute_filename, "main", false, compiler) catch |err| {
-        if (mode == .regular) {
+        compiler.errors.print_errors(error_string.writer(), .{ .print_full_path = false, .print_color = false });
+        if (mode == .bless) {
+            bless_file(filename, error_string.str(), body) catch unreachable;
+            return true;
+        } else if (mode == .regular) {
             switch (err) {
                 error.LexerError,
                 error.CompileError,
                 => {
-                    compiler.errors.print_errors(error_string.writer(), .{ .print_full_path = false, .print_color = false });
                     compiler.errors.print_errors(get_std_out(), .{});
                     return true;
                 },

--- a/src/util/errors.zig
+++ b/src/util/errors.zig
@@ -278,8 +278,8 @@ pub const Error = union(enum) {
         }
     }
 
-    pub fn fatal_error(self: Error) noreturn {
-        self.print_error();
+    pub fn fatal_error(self: Error, writer: anytype, conf: Error_Config) noreturn {
+        self.print_error(writer, conf);
         std.process.exit(1);
     }
 

--- a/src/util/errors.zig
+++ b/src/util/errors.zig
@@ -4,8 +4,14 @@ const std = @import("std");
 const ast_ = @import("../ast/ast.zig");
 const Span = @import("../util/span.zig");
 const Symbol = @import("../symbol/symbol.zig");
+const String = @import("../zig-string/zig-string.zig").String;
 const term_ = @import("term.zig");
 const Token = @import("../lexer/token.zig");
+
+pub const Error_Config = struct {
+    print_full_path: bool = true,
+    print_color: bool = true,
+};
 
 pub const Error = union(enum) {
     // General errors
@@ -156,7 +162,7 @@ pub const Error = union(enum) {
     duplicate: struct {
         span: Span,
         identifier: []const u8,
-        first: ?Span, // printed get_std_err() as extra information
+        first: ?Span, // printed writer as extra information
     },
     member_not_in: struct {
         span: Span,
@@ -277,107 +283,107 @@ pub const Error = union(enum) {
         std.process.exit(1);
     }
 
-    pub fn print_error(self: Error) void {
-        bold.dump(get_std_err()) catch unreachable;
-        print_label(self.get_span(), "error: ", .red);
-        self.print_msg();
-        not_bold.dump(get_std_err()) catch unreachable;
-        print_epilude(self.get_span());
-        self.print_extra_info();
+    pub fn print_error(self: Error, writer: anytype, conf: Error_Config) void {
+        print_color(bold, writer, conf);
+        print_label(self.get_span(), "error: ", .red, writer, conf);
+        self.print_msg(writer);
+        print_color(not_bold, writer, conf);
+        print_epilude(self.get_span(), writer, conf);
+        self.print_extra_info(writer, conf);
     }
 
-    fn print_msg(err: Error) void {
+    fn print_msg(err: Error, writer: anytype) void {
         switch (err) {
             // General errors
-            .basic => get_std_err().print("{s}\n", .{err.basic.msg}) catch unreachable,
+            .basic => writer.print("{s}\n", .{err.basic.msg}) catch unreachable,
 
             // Lexer errors
-            .invalid_digit => get_std_err().print("'{c}' is not a valid {s} digit\n", .{ err.invalid_digit.digit, err.invalid_digit.base }) catch unreachable,
-            .invalid_escape => get_std_err().print("invalid escape sequence '\\{c}'\n", .{err.invalid_escape.digit}) catch unreachable,
+            .invalid_digit => writer.print("'{c}' is not a valid {s} digit\n", .{ err.invalid_digit.digit, err.invalid_digit.base }) catch unreachable,
+            .invalid_escape => writer.print("invalid escape sequence '\\{c}'\n", .{err.invalid_escape.digit}) catch unreachable,
 
             // Parser errors
-            .expected_basic_token => get_std_err().print("expected {s}, got `{s}`\n", .{
+            .expected_basic_token => writer.print("expected {s}, got `{s}`\n", .{
                 err.expected_basic_token.expected,
                 err.expected_basic_token.got.kind.repr() orelse err.expected_basic_token.got.data,
             }) catch unreachable,
-            .expected2token => get_std_err().print("expected `{s}`, got `{s}`\n", .{
+            .expected2token => writer.print("expected `{s}`, got `{s}`\n", .{
                 err.expected2token.expected.repr() orelse "identifier",
                 err.expected2token.got.kind.repr() orelse err.expected2token.got.data,
             }) catch unreachable,
             .missing_close => {
-                get_std_err().print("expected closing `{s}` to match opening `{s}` here, got `{s}`\n", .{
+                writer.print("expected closing `{s}` to match opening `{s}` here, got `{s}`\n", .{
                     err.missing_close.expected.repr() orelse "",
                     err.missing_close.open.kind.repr() orelse err.missing_close.open.data,
                     err.missing_close.got.kind.repr() orelse err.missing_close.got.data,
                 }) catch unreachable;
             },
-            .comptime_known => get_std_err().print("{s} must be compile-time known\n", .{err.comptime_known.what}) catch unreachable,
+            .comptime_known => writer.print("{s} must be compile-time known\n", .{err.comptime_known.what}) catch unreachable,
 
             // Symbol
-            .redefinition => get_std_err().print("redefinition of symbol `{s}`\n", .{err.redefinition.name}) catch unreachable,
-            .symbol_error => get_std_err().print("symbol `{s}` {s}\n", .{ err.symbol_error.name, err.symbol_error.problem }) catch unreachable,
-            .discard_marked => get_std_err().print("discarded symbol marked as `{s}`\n", .{@tagName(err.discard_marked.kind)}) catch unreachable,
-            .not_inside_loop => get_std_err().print("`{s}` is not inside a loop\n", .{err.not_inside_loop.name}) catch unreachable,
-            .not_inside_function => get_std_err().print("`{s}` is not inside a function\n", .{err.not_inside_function.name}) catch unreachable,
-            .import_file_not_found => get_std_err().print("file `{s}.orng` not found\n", .{err.import_file_not_found.filename}) catch unreachable,
+            .redefinition => writer.print("redefinition of symbol `{s}`\n", .{err.redefinition.name}) catch unreachable,
+            .symbol_error => writer.print("symbol `{s}` {s}\n", .{ err.symbol_error.name, err.symbol_error.problem }) catch unreachable,
+            .discard_marked => writer.print("discarded symbol marked as `{s}`\n", .{@tagName(err.discard_marked.kind)}) catch unreachable,
+            .not_inside_loop => writer.print("`{s}` is not inside a loop\n", .{err.not_inside_loop.name}) catch unreachable,
+            .not_inside_function => writer.print("`{s}` is not inside a function\n", .{err.not_inside_function.name}) catch unreachable,
+            .import_file_not_found => writer.print("file `{s}.orng` not found\n", .{err.import_file_not_found.filename}) catch unreachable,
 
             // Traits
             .reimpl => if (err.reimpl.name != null) {
-                get_std_err().print("duplicate implementation of trait `{s}` for the type `", .{err.reimpl.name.?}) catch unreachable;
-                err.reimpl._type.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("`\n", .{}) catch unreachable;
+                writer.print("duplicate implementation of trait `{s}` for the type `", .{err.reimpl.name.?}) catch unreachable;
+                err.reimpl._type.print_type(writer) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
             } else {
-                get_std_err().print("duplicate implementation for the type `", .{}) catch unreachable;
-                err.reimpl._type.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("`\n", .{}) catch unreachable;
+                writer.print("duplicate implementation for the type `", .{}) catch unreachable;
+                err.reimpl._type.print_type(writer) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
             },
             .type_not_impl_method => {
-                get_std_err().print("the type `", .{}) catch unreachable;
-                err.type_not_impl_method._type.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("` does not implement the method `{s}`\n", .{err.type_not_impl_method.method_name}) catch unreachable;
+                writer.print("the type `", .{}) catch unreachable;
+                err.type_not_impl_method._type.print_type(writer) catch unreachable;
+                writer.print("` does not implement the method `{s}`\n", .{err.type_not_impl_method.method_name}) catch unreachable;
             },
             .type_not_impl_trait => {
-                get_std_err().print("the type `", .{}) catch unreachable;
-                err.type_not_impl_trait._type.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("` does not implement the trait `{s}`\n", .{err.type_not_impl_trait.trait_name}) catch unreachable;
+                writer.print("the type `", .{}) catch unreachable;
+                err.type_not_impl_trait._type.print_type(writer) catch unreachable;
+                writer.print("` does not implement the trait `{s}`\n", .{err.type_not_impl_trait.trait_name}) catch unreachable;
             },
-            .method_not_in_trait => get_std_err().print("method `{s}` is not in trait `{s}`\n", .{
+            .method_not_in_trait => writer.print("method `{s}` is not in trait `{s}`\n", .{
                 err.method_not_in_trait.method_name,
                 err.method_not_in_trait.trait_name,
             }) catch unreachable,
-            .method_not_in_impl => get_std_err().print("missing implementation of method `{s}` from trait `{s}`\n", .{
+            .method_not_in_impl => writer.print("missing implementation of method `{s}` from trait `{s}`\n", .{
                 err.method_not_in_impl.method_name,
                 err.method_not_in_impl.trait_name,
             }) catch unreachable,
             .impl_receiver_mismatch => if (err.impl_receiver_mismatch.trait_receiver != null and err.impl_receiver_mismatch.impl_receiver != null) {
-                get_std_err().print("trait `{s}` specifies receiver `{s}` for method `{s}`, got receiver `{s}`\n", .{
+                writer.print("trait `{s}` specifies receiver `{s}` for method `{s}`, got receiver `{s}`\n", .{
                     err.impl_receiver_mismatch.trait_name,
                     err.impl_receiver_mismatch.trait_receiver.?.to_string(),
                     err.impl_receiver_mismatch.method_name,
                     err.impl_receiver_mismatch.impl_receiver.?.to_string(),
                 }) catch unreachable;
             } else if (err.impl_receiver_mismatch.trait_receiver == null and err.impl_receiver_mismatch.impl_receiver != null) {
-                get_std_err().print("trait `{s}` does not specify a receiver for method `{s}`, got receiver `{s}`\n", .{
+                writer.print("trait `{s}` does not specify a receiver for method `{s}`, got receiver `{s}`\n", .{
                     err.impl_receiver_mismatch.trait_name,
                     err.impl_receiver_mismatch.method_name,
                     err.impl_receiver_mismatch.impl_receiver.?.to_string(),
                 }) catch unreachable;
             } else if (err.impl_receiver_mismatch.trait_receiver != null and err.impl_receiver_mismatch.impl_receiver == null) {
-                get_std_err().print("trait `{s}` specifies receiver `{s}` for method `{s}`\n", .{
+                writer.print("trait `{s}` specifies receiver `{s}` for method `{s}`\n", .{
                     err.impl_receiver_mismatch.trait_name,
                     err.impl_receiver_mismatch.trait_receiver.?.to_string(),
                     err.impl_receiver_mismatch.method_name,
                 }) catch unreachable;
             },
             .invoke_receiver_mismatch => {
-                get_std_err().print("receiver `{s}` of method `{s}` incompatible with type `", .{
+                writer.print("receiver `{s}` of method `{s}` incompatible with type `", .{
                     err.invoke_receiver_mismatch.method_receiver.to_string(),
                     err.invoke_receiver_mismatch.method_name,
                 }) catch unreachable;
-                err.invoke_receiver_mismatch.lhs_type.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("`\n", .{}) catch unreachable;
+                err.invoke_receiver_mismatch.lhs_type.print_type(writer) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
             },
-            .mismatch_method_param_arity => get_std_err().print("trait `{s}` specifies {} parameter{s} for method `{s}`, got {}\n", .{
+            .mismatch_method_param_arity => writer.print("trait `{s}` specifies {} parameter{s} for method `{s}`, got {}\n", .{
                 err.mismatch_method_param_arity.trait_name,
                 err.mismatch_method_param_arity.trait_arity,
                 if (err.mismatch_method_param_arity.trait_arity != 1) "s" else "",
@@ -385,14 +391,14 @@ pub const Error = union(enum) {
                 err.mismatch_method_param_arity.impl_arity,
             }) catch unreachable,
             .mismatch_method_type => {
-                get_std_err().print("trait `{s}` specifies type `", .{err.mismatch_method_type.trait_name}) catch unreachable;
-                err.mismatch_method_type.trait_type.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("` for method `{s}`, got `", .{err.mismatch_method_type.method_name}) catch unreachable;
-                err.mismatch_method_type.impl_type.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("`\n", .{}) catch unreachable;
+                writer.print("trait `{s}` specifies type `", .{err.mismatch_method_type.trait_name}) catch unreachable;
+                err.mismatch_method_type.trait_type.print_type(writer) catch unreachable;
+                writer.print("` for method `{s}`, got `", .{err.mismatch_method_type.method_name}) catch unreachable;
+                err.mismatch_method_type.impl_type.print_type(writer) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
             },
             .mismatch_method_virtuality => {
-                get_std_err().print("trait `{s}` specifies the method `{s}` as {s}, got {s}\n", .{
+                writer.print("trait `{s}` specifies the method `{s}` as {s}, got {s}\n", .{
                     err.mismatch_method_virtuality.trait_name,
                     err.mismatch_method_virtuality.method_name,
                     if (err.mismatch_method_virtuality.trait_method_is_virtual) "virtual" else "non-virtual",
@@ -400,7 +406,7 @@ pub const Error = union(enum) {
                 }) catch unreachable;
             },
             .trait_virtual_refers_to_self => {
-                get_std_err().print("virtual method `{s}` of trait `{s}` refers to `Self` type\n", .{
+                writer.print("virtual method `{s}` of trait `{s}` refers to `Self` type\n", .{
                     err.trait_virtual_refers_to_self.method_name,
                     err.trait_virtual_refers_to_self.trait_name,
                 }) catch unreachable;
@@ -409,47 +415,47 @@ pub const Error = union(enum) {
             // Typecheck
             .unexpected_type => if (err.unexpected_type.expected.* == .identifier and std.mem.eql(u8, err.unexpected_type.expected.token().data, "Void")) {
                 std.debug.assert(err.unexpected_type.expected.* != .poison);
-                get_std_err().print("cannot assign a value of type `", .{}) catch unreachable;
-                err.unexpected_type.got.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("` to type `Void`\n", .{}) catch unreachable;
+                writer.print("cannot assign a value of type `", .{}) catch unreachable;
+                err.unexpected_type.got.print_type(writer) catch unreachable;
+                writer.print("` to type `Void`\n", .{}) catch unreachable;
             } else {
                 std.debug.assert(err.unexpected_type.expected.* != .poison);
-                get_std_err().print("expected a value of type `", .{}) catch unreachable;
-                err.unexpected_type.expected.print_type(get_std_err()) catch unreachable;
+                writer.print("expected a value of type `", .{}) catch unreachable;
+                err.unexpected_type.expected.print_type(writer) catch unreachable;
                 if (err.unexpected_type.got.* != .poison) {
-                    get_std_err().print("`, got a value of type `", .{}) catch unreachable;
-                    err.unexpected_type.got.print_type(get_std_err()) catch unreachable;
+                    writer.print("`, got a value of type `", .{}) catch unreachable;
+                    err.unexpected_type.got.print_type(writer) catch unreachable;
                 }
-                get_std_err().print("`\n", .{}) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
             },
             .expected_builtin_typeclass => {
-                get_std_err().print("expected a value of a(n) {s} type, got `", .{err.expected_builtin_typeclass.expected}) catch unreachable;
-                err.expected_builtin_typeclass.got.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("`\n", .{}) catch unreachable;
+                writer.print("expected a value of a(n) {s} type, got `", .{err.expected_builtin_typeclass.expected}) catch unreachable;
+                err.expected_builtin_typeclass.got.print_type(writer) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
             },
-            .duplicate => get_std_err().print("duplicate item `{s}`\n", .{err.duplicate.identifier}) catch unreachable,
+            .duplicate => writer.print("duplicate item `{s}`\n", .{err.duplicate.identifier}) catch unreachable,
             .member_not_in => {
-                get_std_err().print("member `{s}` not in {s}: `", .{ err.member_not_in.identifier, err.member_not_in.name }) catch unreachable;
-                err.member_not_in.group.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("`\n", .{}) catch unreachable;
+                writer.print("member `{s}` not in {s}: `", .{ err.member_not_in.identifier, err.member_not_in.name }) catch unreachable;
+                err.member_not_in.group.print_type(writer) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
             },
-            .undeclared_identifier => get_std_err().print("use of undeclared identifier `{s}`\n", .{err.undeclared_identifier.identifier.data}) catch unreachable,
-            .comptime_access_runtime => get_std_err().print("cannot access non-const variable `{s}` in a comptime context\n", .{
+            .undeclared_identifier => writer.print("use of undeclared identifier `{s}`\n", .{err.undeclared_identifier.identifier.data}) catch unreachable,
+            .comptime_access_runtime => writer.print("cannot access non-const variable `{s}` in a comptime context\n", .{
                 err.comptime_access_runtime.identifier.data,
             }) catch unreachable,
-            .inner_fn_access_runtime => get_std_err().print("cannot access non-const variable `{s}` from an inner-function\n", .{
+            .inner_fn_access_runtime => writer.print("cannot access non-const variable `{s}` from an inner-function\n", .{
                 err.inner_fn_access_runtime.identifier.data,
             }) catch unreachable,
-            .use_before_def => get_std_err().print("use of identifier `{s}` before its definition\n", .{err.use_before_def.identifier.data}) catch unreachable,
-            .modify_immutable => get_std_err().print("cannot modify non-mutable symbol `{s}`\n", .{err.modify_immutable.identifier.data}) catch unreachable,
+            .use_before_def => writer.print("use of identifier `{s}` before its definition\n", .{err.use_before_def.identifier.data}) catch unreachable,
+            .modify_immutable => writer.print("cannot modify non-mutable symbol `{s}`\n", .{err.modify_immutable.identifier.data}) catch unreachable,
             .not_indexable => {
-                get_std_err().print("the type `", .{}) catch unreachable;
-                err.not_indexable._type.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("` is not indexable\n", .{}) catch unreachable;
+                writer.print("the type `", .{}) catch unreachable;
+                err.not_indexable._type.print_type(writer) catch unreachable;
+                writer.print("` is not indexable\n", .{}) catch unreachable;
             },
-            .non_exhaustive_sum => get_std_err().print("match over sum type is not exhaustive\n", .{}) catch unreachable,
+            .non_exhaustive_sum => writer.print("match over sum type is not exhaustive\n", .{}) catch unreachable,
             .mismatch_arity => {
-                get_std_err().print("{s} takes {} {s}{s}, {} {s}{s} given\n", .{
+                writer.print("{s} takes {} {s}{s}, {} {s}{s} given\n", .{
                     err.mismatch_arity.thing_name,
                     err.mismatch_arity.takes,
                     err.mismatch_arity.takes_name,
@@ -460,111 +466,111 @@ pub const Error = union(enum) {
                 }) catch unreachable;
             },
             .no_default => {
-                get_std_err().print("no default value for type `", .{}) catch unreachable;
-                err.no_default._type.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("`\n", .{}) catch unreachable;
+                writer.print("no default value for type `", .{}) catch unreachable;
+                err.no_default._type.print_type(writer) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
             },
             .wrong_from => {
-                get_std_err().print("expected {s} type for {s}, got `", .{
+                writer.print("expected {s} type for {s}, got `", .{
                     err.wrong_from.from,
                     err.wrong_from.operator,
                 }) catch unreachable;
-                err.wrong_from.got.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("`\n", .{}) catch unreachable;
+                err.wrong_from.got.print_type(writer) catch unreachable;
+                writer.print("`\n", .{}) catch unreachable;
             },
             .integer_out_of_bounds => {
-                get_std_err().print("error: integer is out of bounds for type `", .{}) catch unreachable;
-                err.integer_out_of_bounds.expected.print_type(get_std_err()) catch unreachable;
-                get_std_err().print("`; value={}\n", .{err.integer_out_of_bounds.value}) catch unreachable;
+                writer.print("error: integer is out of bounds for type `", .{}) catch unreachable;
+                err.integer_out_of_bounds.expected.print_type(writer) catch unreachable;
+                writer.print("`; value={}\n", .{err.integer_out_of_bounds.value}) catch unreachable;
             },
             .invalid_type => {
-                get_std_err().print("error: expected a compile-time constant type, got {s}\n", .{@tagName(err.invalid_type.got.*)}) catch unreachable;
+                writer.print("error: expected a compile-time constant type, got {s}\n", .{@tagName(err.invalid_type.got.*)}) catch unreachable;
             },
             .recursive_definition => if (err.recursive_definition.symbol_name) |symbol_name| {
-                get_std_err().print("error: recursive definition of symbol `{s}` detected\n", .{symbol_name}) catch unreachable;
+                writer.print("error: recursive definition of symbol `{s}` detected\n", .{symbol_name}) catch unreachable;
             } else {
-                get_std_err().print("error: recursive definition detected\n", .{}) catch unreachable;
+                writer.print("error: recursive definition detected\n", .{}) catch unreachable;
             },
         }
     }
 
-    fn print_extra_info(self: Error) void {
+    fn print_extra_info(self: Error, writer: anytype, conf: Error_Config) void {
         // FIXME: High Cyclo
         switch (self) {
             .missing_close => {
-                bold.dump(get_std_err()) catch unreachable;
-                print_note_label(self.missing_close.open.span);
-                bold.dump(get_std_err()) catch unreachable;
-                get_std_err().print("opening `{s}` here:\n", .{self.missing_close.open.kind.repr() orelse self.missing_close.open.data}) catch unreachable;
-                not_bold.dump(get_std_err()) catch unreachable;
-                print_epilude(self.missing_close.open.span);
+                print_color(bold, writer, conf);
+                print_note_label(self.missing_close.open.span, writer, conf);
+                print_color(bold, writer, conf);
+                writer.print("opening `{s}` here:\n", .{self.missing_close.open.kind.repr() orelse self.missing_close.open.data}) catch unreachable;
+                print_color(not_bold, writer, conf);
+                print_epilude(self.missing_close.open.span, writer, conf);
             },
             .comptime_known => {
-                bold.dump(get_std_err()) catch unreachable;
-                print_note_label(self.comptime_known.span);
-                bold.dump(get_std_err()) catch unreachable;
-                get_std_err().print("consider wrapping with `comptime`\n", .{}) catch unreachable;
-                not_bold.dump(get_std_err()) catch unreachable;
+                print_color(bold, writer, conf);
+                print_note_label(self.comptime_known.span, writer, conf);
+                print_color(bold, writer, conf);
+                writer.print("consider wrapping with `comptime`\n", .{}) catch unreachable;
+                print_color(not_bold, writer, conf);
             },
             .redefinition => {
                 if (self.redefinition.first_defined_span.line_number != 0) { // Don't print redefinitions for places that don't exist
-                    bold.dump(get_std_err()) catch unreachable;
-                    print_note_label(self.redefinition.first_defined_span);
-                    bold.dump(get_std_err()) catch unreachable;
-                    get_std_err().print("other definition of `{s}` here:\n", .{self.redefinition.name}) catch unreachable;
-                    not_bold.dump(get_std_err()) catch unreachable;
-                    print_epilude(self.redefinition.first_defined_span);
+                    print_color(bold, writer, conf);
+                    print_note_label(self.redefinition.first_defined_span, writer, conf);
+                    print_color(bold, writer, conf);
+                    writer.print("other definition of `{s}` here:\n", .{self.redefinition.name}) catch unreachable;
+                    print_color(not_bold, writer, conf);
+                    print_epilude(self.redefinition.first_defined_span, writer, conf);
                 }
             },
             .symbol_error => {
                 if (self.symbol_error.context_span != null) {
-                    bold.dump(get_std_err()) catch unreachable;
-                    print_note_label(self.symbol_error.context_span.?);
-                    bold.dump(get_std_err()) catch unreachable;
-                    get_std_err().print("{s}\n", .{self.symbol_error.context_message}) catch unreachable;
-                    not_bold.dump(get_std_err()) catch unreachable;
-                    print_epilude(self.symbol_error.context_span.?);
+                    print_color(bold, writer, conf);
+                    print_note_label(self.symbol_error.context_span.?, writer, conf);
+                    print_color(bold, writer, conf);
+                    writer.print("{s}\n", .{self.symbol_error.context_message}) catch unreachable;
+                    print_color(not_bold, writer, conf);
+                    print_epilude(self.symbol_error.context_span.?, writer, conf);
                 }
             },
             .duplicate => if (self.duplicate.first != null) {
-                bold.dump(get_std_err()) catch unreachable;
-                print_note_label(self.duplicate.first);
-                bold.dump(get_std_err()) catch unreachable;
-                get_std_err().print("other definition of `{s}` here:\n", .{self.duplicate.identifier}) catch unreachable;
-                not_bold.dump(get_std_err()) catch unreachable;
-                print_epilude(self.duplicate.first);
+                print_color(bold, writer, conf);
+                print_note_label(self.duplicate.first, writer, conf);
+                print_color(bold, writer, conf);
+                writer.print("other definition of `{s}` here:\n", .{self.duplicate.identifier}) catch unreachable;
+                print_color(not_bold, writer, conf);
+                print_epilude(self.duplicate.first, writer, conf);
             },
             .non_exhaustive_sum => {
                 for (self.non_exhaustive_sum.forgotten.items) |_type| {
-                    bold.dump(get_std_err()) catch unreachable;
-                    print_note_label(_type.token().span);
-                    bold.dump(get_std_err()) catch unreachable;
-                    get_std_err().print("term not handled: `{s}`\n", .{_type.annotation.pattern.token().data}) catch unreachable;
-                    not_bold.dump(get_std_err()) catch unreachable;
-                    print_epilude(_type.token().span);
+                    print_color(bold, writer, conf);
+                    print_note_label(_type.token().span, writer, conf);
+                    print_color(bold, writer, conf);
+                    writer.print("term not handled: `{s}`\n", .{_type.annotation.pattern.token().data}) catch unreachable;
+                    print_color(not_bold, writer, conf);
+                    print_epilude(_type.token().span, writer, conf);
                 }
             },
             .reimpl => {
                 if (self.reimpl.first_defined_span.line_number != 0) { // Don't print reimpls for places that don't exist!
-                    bold.dump(get_std_err()) catch unreachable;
-                    print_note_label(self.reimpl.first_defined_span);
-                    bold.dump(get_std_err()) catch unreachable;
+                    print_color(bold, writer, conf);
+                    print_note_label(self.reimpl.first_defined_span, writer, conf);
+                    print_color(bold, writer, conf);
                     if (self.reimpl.name != null) {
-                        get_std_err().print("other implementation of `{s}` here:\n", .{self.reimpl.name.?}) catch unreachable;
+                        writer.print("other implementation of `{s}` here:\n", .{self.reimpl.name.?}) catch unreachable;
                     } else {
-                        get_std_err().print("other implementation here:\n", .{}) catch unreachable;
+                        writer.print("other implementation here:\n", .{}) catch unreachable;
                     }
-                    not_bold.dump(get_std_err()) catch unreachable;
-                    print_epilude(self.reimpl.first_defined_span);
+                    print_color(not_bold, writer, conf);
+                    print_epilude(self.reimpl.first_defined_span, writer, conf);
                 }
             },
             .method_not_in_impl => {
-                bold.dump(get_std_err()) catch unreachable;
-                print_note_label(self.method_not_in_impl.method_span);
-                bold.dump(get_std_err()) catch unreachable;
-                get_std_err().print("method specification here:\n", .{}) catch unreachable;
-                not_bold.dump(get_std_err()) catch unreachable;
-                print_epilude(self.method_not_in_impl.method_span);
+                print_color(bold, writer, conf);
+                print_note_label(self.method_not_in_impl.method_span, writer, conf);
+                print_color(bold, writer, conf);
+                writer.print("method specification here:\n", .{}) catch unreachable;
+                print_color(not_bold, writer, conf);
+                print_epilude(self.method_not_in_impl.method_span, writer, conf);
             },
             else => {},
         }
@@ -577,12 +583,13 @@ pub const Error = union(enum) {
 };
 
 // This is for compatability with Windows, since stdout for Windows isn't known at compile-time
-fn get_std_err() std.fs.File.Writer {
+pub fn get_std_err() std.fs.File.Writer {
     return std.io.getStdErr().writer();
 }
 
 const bold = term_.Attr{ .bold = true };
 const not_bold = term_.Attr{ .bold = false };
+
 pub const Errors = struct {
     errors_list: std.ArrayList(Error),
 
@@ -601,40 +608,56 @@ pub const Errors = struct {
         // err.peek_error(); // uncomment if you want to see where errors come from TODO: Make this a cmd line flag
     }
 
-    pub fn print_errors(self: *Errors) void {
+    /// Prints out all errors in the Errors list
+    pub fn print_errors(self: *Errors, writer: anytype, conf: Error_Config) void {
         for (self.errors_list.items) |err| {
-            err.print_error();
+            err.print_error(writer, conf);
         }
     }
 };
 
-fn print_note_label(maybe_span: ?Span) void {
-    print_label(maybe_span, "note: ", .cyan);
+fn print_note_label(maybe_span: ?Span, writer: anytype, conf: Error_Config) void {
+    print_label(maybe_span, "note: ", .cyan, writer, conf);
 }
 
-fn print_epilude(maybe_span: ?Span) void {
+fn print_epilude(maybe_span: ?Span, writer: anytype, conf: Error_Config) void {
     if (maybe_span) |old_span| {
         const span = old_span;
         if (span.line_number == 0) {
             return;
         } else if (span.line_text.len > 0) {
-            not_bold.dump(get_std_err()) catch unreachable;
-            get_std_err().print("{s}\n", .{span.line_text}) catch unreachable;
+            print_color(not_bold, writer, conf);
+            writer.print("{s}\n", .{span.line_text}) catch unreachable;
         }
         for (2..span.col) |_| {
-            get_std_err().print(" ", .{}) catch unreachable;
+            writer.print(" ", .{}) catch unreachable;
         }
-        term_.outputColor(term_.Attr{ .fg = .green, .bold = true }, "^\n", get_std_err()) catch unreachable;
+        if (conf.print_color) {
+            term_.outputColor(term_.Attr{ .fg = .green, .bold = true }, "^\n", writer) catch unreachable;
+        } else {
+            writer.print("^\n", .{}) catch unreachable;
+        }
     }
 }
 
-fn print_label(maybe_span: ?Span, label: []const u8, color: term_.Color) void {
+fn print_label(maybe_span: ?Span, label: []const u8, color: term_.Color, writer: anytype, conf: Error_Config) void {
     if (maybe_span) |span| {
+        const filename = if (conf.print_full_path) span.filename else std.fs.path.basename(span.filename);
         if (span.line_number > 0 and span.col > 0) {
-            get_std_err().print("{s}:{}:{}: ", .{ span.filename, span.line_number, span.col }) catch unreachable;
-        } else if (span.filename.len > 0) {
-            get_std_err().print("{s}: ", .{span.filename}) catch unreachable;
+            writer.print("{s}:{}:{}: ", .{ filename, span.line_number, span.col }) catch unreachable;
+        } else if (filename.len > 0) {
+            writer.print("{s}: ", .{filename}) catch unreachable;
         }
     }
-    term_.outputColor(term_.Attr{ .fg = color, .bold = true }, label, get_std_err()) catch unreachable;
+    if (conf.print_color) {
+        term_.outputColor(term_.Attr{ .fg = color, .bold = true }, label, writer) catch unreachable;
+    } else {
+        writer.print("{s}", .{label}) catch unreachable;
+    }
+}
+
+fn print_color(attr: term_.Attr, writer: anytype, conf: Error_Config) void {
+    if (conf.print_color) {
+        attr.dump(writer) catch unreachable;
+    }
 }

--- a/tests/negative/comptime/add_oob.orng
+++ b/tests/negative/comptime/add_oob.orng
@@ -1,3 +1,4 @@
+// 
 fn main() -> () {
     _ = comptime {add(100, 50)}
 }

--- a/tests/negative/comptime/if_reduce_let_false_unit.orng
+++ b/tests/negative/comptime/if_reduce_let_false_unit.orng
@@ -1,3 +1,7 @@
+// if_reduce_let_false_unit.orng:6:17: error: symbol `x` is never used
+//     _ = if let x = 4 ; false { } else { }
+//                ^
+// 
 fn main() -> Int { 
     _ = if let x = 4 ; false { } else { }
     322

--- a/tests/negative/comptime/if_reduce_let_true_unit.orng
+++ b/tests/negative/comptime/if_reduce_let_true_unit.orng
@@ -1,3 +1,7 @@
+// if_reduce_let_true_unit.orng:6:17: error: symbol `x` is never used
+//     _ = if let x = 4 ; true { }
+//                ^
+// 
 fn main() -> Int { 
     _ = if let x = 4 ; true { }
     321

--- a/tests/negative/comptime/if_reduce_let_true_unit_else.orng
+++ b/tests/negative/comptime/if_reduce_let_true_unit_else.orng
@@ -1,3 +1,7 @@
+// if_reduce_let_true_unit_else.orng:6:17: error: symbol `x` is never used
+//     _ = if let x = 4 ; true { } else { }
+//                ^
+// 
 fn main() -> Int { 
     _ = if let x = 4 ; true { } else { }
     322

--- a/tests/negative/comptime/int_oob.orng
+++ b/tests/negative/comptime/int_oob.orng
@@ -1,3 +1,7 @@
+// int_oob.orng:5:22: error: error: integer is out of bounds for type `Int8`; value=150
+// const x: Int8 = 100 + 50
+//                     ^
+// 
 const x: Int8 = 100 + 50
 fn main() -> Int8 {
     x

--- a/tests/negative/comptime/return_in_comptime.orng
+++ b/tests/negative/comptime/return_in_comptime.orng
@@ -1,3 +1,7 @@
+// return_in_comptime.orng:6:15: error: comptime cannot be type `Void`
+//     comptime { return 3 } 
+//              ^
+// 
 fn main() -> Int { 
     comptime { return 3 } 
 }

--- a/tests/negative/comptime/self_referential_const.orng
+++ b/tests/negative/comptime/self_referential_const.orng
@@ -1,3 +1,7 @@
+// self_referential_const.orng:5:8: error: error: recursive definition of symbol `x` detected
+// const x = comptime{x}
+//       ^
+// 
 const x = comptime{x}
 
 fn main() -> Int {0}

--- a/tests/negative/comptime/self_referential_fn.orng
+++ b/tests/negative/comptime/self_referential_fn.orng
@@ -1,3 +1,7 @@
+// self_referential_fn.orng:5:8: error: error: recursive definition of symbol `main` detected
+// fn main() -> Int {
+//       ^
+// 
 fn main() -> Int {
     // This can't be checked properly because slice-of can't know if comptime is valid without knowing if slice-of is valid
     []comptime {main}

--- a/tests/negative/comptime/unreachable.orng
+++ b/tests/negative/comptime/unreachable.orng
@@ -1,3 +1,7 @@
+// unreachable.orng:6:28: error: comptime cannot be type `Void`
+//     let x: Int = comptime { unreachable }
+//                           ^
+// 
 fn main() -> Int {
     let x: Int = comptime { unreachable }
     x

--- a/tests/negative/comptime/untagged_sum_type.orng
+++ b/tests/negative/comptime/untagged_sum_type.orng
@@ -1,3 +1,7 @@
+// untagged_sum_type.orng:6:23: error: comptime untagged sum values cannot propagate to runtime
+//     let x = comptime {
+//                      ^
+// 
 fn main() -> Int {
     let x = comptime {
         let mut y: @Untagged(?Int) = undefined

--- a/tests/negative/comptime/use_rt.orng
+++ b/tests/negative/comptime/use_rt.orng
@@ -1,3 +1,10 @@
+// use_rt.orng:10:32: error: symbol `x` is never defined
+//     let y: Int = comptime { x + 4 }
+//                               ^
+// use_rt.orng:9:10: note: declared here
+//     let x: Int = 4
+//         ^
+// 
 fn main() -> Int {
     let x: Int = 4
     let y: Int = comptime { x + 4 }

--- a/tests/negative/externs/default_opaque_extern.orng
+++ b/tests/negative/externs/default_opaque_extern.orng
@@ -1,3 +1,8 @@
+// default_opaque_extern.orng:10:29: error: no default value for type `C_Int`
+//         let mut xs: [5]C_Int
+//                            ^
+// error: comptime cannot be type `Void`
+// 
 extern ("int") const C_Int: Type
 
 fn main() -> Int {

--- a/tests/negative/externs/variadic_arity.orng
+++ b/tests/negative/externs/variadic_arity.orng
@@ -1,3 +1,7 @@
+// variadic_arity.orng:8:12: error: function takes 1 parameter, 0 arguments given
+//     printf()
+//           ^
+// 
 extern const printf: [*]Byte -> Int32
 
 fn main() -> Int {

--- a/tests/negative/generics/const_fn_anonymous.orng
+++ b/tests/negative/generics/const_fn_anonymous.orng
@@ -1,3 +1,7 @@
+// const_fn_anonymous.orng:5:3: error: anonymous functions specified with const parameters
+// fn (const n: Int) -> Int {
+//  ^
+// 
 fn (const n: Int) -> Int {
     n + 4
 }

--- a/tests/negative/generics/const_fn_mismatch_arity.orng
+++ b/tests/negative/generics/const_fn_mismatch_arity.orng
@@ -1,3 +1,7 @@
+// const_fn_mismatch_arity.orng:11:21: error: function takes 2 parameters, 1 argument given
+//     let x: template(4) = ('1', '2', '3', '4')
+//                    ^
+// 
 fn template(const n: Int, x: Int) -> Type {
     _ = x
     [n]Char

--- a/tests/negative/generics/const_fn_mismatch_ret.orng
+++ b/tests/negative/generics/const_fn_mismatch_ret.orng
@@ -1,3 +1,7 @@
+// const_fn_mismatch_ret.orng:10:14: error: expected a value of type `Char`, got a value of type `Int`
+//     template(4)
+//             ^
+// 
 fn template(const n: Int) -> Int {
     n + 4
 }

--- a/tests/negative/generics/const_fn_mismatch_type.orng
+++ b/tests/negative/generics/const_fn_mismatch_type.orng
@@ -1,3 +1,7 @@
+// const_fn_mismatch_type.orng:11:24: error: expected a value of type `Int`, got a value of type `Float`
+//     let x: template(4.0, 4.0) = ('1', '2', '3', '4')
+//                       ^
+// 
 fn template(const n: Int, x: Int) -> Type {
     _ = x
     [n]Char

--- a/tests/negative/generics/const_fn_redecl.orng
+++ b/tests/negative/generics/const_fn_redecl.orng
@@ -1,3 +1,10 @@
+// const_fn_redecl.orng:12:12: error: redefinition of symbol `template`
+// fn template(const n: Int) -> Int {
+//           ^
+// const_fn_redecl.orng:8:12: note: other definition of `template` here:
+// fn template(const n: Int) -> Int {
+//           ^
+// 
 fn template(const n: Int) -> Int {
     n + 4
 }

--- a/tests/negative/generics/const_fn_value.orng
+++ b/tests/negative/generics/const_fn_value.orng
@@ -1,3 +1,7 @@
+// const_fn_value.orng:10:33: error: expected a value of type `Int->Int`, got a value of type `()`
+//     let x: Int -> Int = template
+//                                ^
+// 
 fn template(const n: Int) -> Int {
     n + 4
 }

--- a/tests/negative/lexer/CamelCase.orng
+++ b/tests/negative/lexer/CamelCase.orng
@@ -1,3 +1,7 @@
+// CamelCase.orng:6:14: error: camelCase is not supported
+//     let CamelCase = 0
+//             ^
+// 
 fn main() -> Int {
     let CamelCase = 0
     CamelCase

--- a/tests/negative/lexer/binary_digit.orng
+++ b/tests/negative/lexer/binary_digit.orng
@@ -1,3 +1,7 @@
+// binary_digit.orng:6:8: error: 'X' is not a valid binary digit
+//     0bXYZ
+//       ^
+// 
 fn main() -> Int {
     0bXYZ
 }

--- a/tests/negative/lexer/camelCase.orng
+++ b/tests/negative/lexer/camelCase.orng
@@ -1,3 +1,7 @@
+// camelCase.orng:6:14: error: camelCase is not supported
+//     let CamelCase = 0
+//             ^
+// 
 fn main() -> Int {
     let CamelCase = 0
     CamelCase

--- a/tests/negative/lexer/camel_case2.orng
+++ b/tests/negative/lexer/camel_case2.orng
@@ -1,3 +1,7 @@
+// camel_case2.orng:5:10: error: camelCase is not supported
+// const C4Mel: Type = Int
+//         ^
+// 
 const C4Mel: Type = Int
 
 fn main() -> Int {

--- a/tests/negative/lexer/char_codepoints.orng
+++ b/tests/negative/lexer/char_codepoints.orng
@@ -1,3 +1,7 @@
+// char_codepoints.orng:6:67: error: more than one codepoint specified in character literal
+//     let x = 'this character has too many unicode codepoints in it'
+//                                                                  ^
+// 
 fn main() -> Int {
     let x = 'this character has too many unicode codepoints in it'
     0

--- a/tests/negative/lexer/char_eof.orng
+++ b/tests/negative/lexer/char_eof.orng
@@ -1,2 +1,6 @@
+// char_eof.orng:6:48: error: expected a `'`, got end-of-file
+//     let x = 'this character doesnt have an end!
+//                                               ^
+// 
 fn main() -> Int {
     let x = 'this character doesnt have an end!

--- a/tests/negative/lexer/char_escape_eof.orng
+++ b/tests/negative/lexer/char_escape_eof.orng
@@ -1,2 +1,6 @@
+// char_escape_eof.orng:6:49: error: expected a character, got end-of-file
+//     let x = 'this character doesnt have an end!\
+//                                                ^
+// 
 fn main() -> Int {
     let x = 'this character doesnt have an end!\

--- a/tests/negative/lexer/char_invalid.orng
+++ b/tests/negative/lexer/char_invalid.orng
@@ -1,3 +1,7 @@
+// char_invalid.orng:6:16: error: invalid escape sequence '\d'
+//     let x = '\d'
+//               ^
+// 
 fn main() -> Int {
     let x = '\d'
     0

--- a/tests/negative/lexer/double_underscore.orng
+++ b/tests/negative/lexer/double_underscore.orng
@@ -1,3 +1,7 @@
+// double_underscore.orng:6:12: error: may not have more than one underscore in a row in an identifier
+//     let x__lol = 4
+//           ^
+// 
 fn main() -> Int {
     let x__lol = 4
     x__lol

--- a/tests/negative/lexer/float_digit.orng
+++ b/tests/negative/lexer/float_digit.orng
@@ -1,3 +1,7 @@
+// float_digit.orng:6:10: error: 'a' is not a valid decimal digit
+//     0.1_abc
+//         ^
+// 
 fn main() -> Int {
     0.1_abc
     0

--- a/tests/negative/lexer/hex_digit.orng
+++ b/tests/negative/lexer/hex_digit.orng
@@ -1,3 +1,7 @@
+// hex_digit.orng:6:8: error: 'X' is not a valid hexadecimal digit
+//     0xXYZ
+//       ^
+// 
 fn main() -> Int {
     0xXYZ
 }

--- a/tests/negative/lexer/int_digit.orng
+++ b/tests/negative/lexer/int_digit.orng
@@ -1,3 +1,7 @@
+// int_digit.orng:6:9: error: 'a' is not a valid decimal digit
+//     01_abc
+//        ^
+// 
 fn main() -> Int {
     01_abc
 }

--- a/tests/negative/lexer/octal_digit.orng
+++ b/tests/negative/lexer/octal_digit.orng
@@ -1,3 +1,7 @@
+// octal_digit.orng:6:8: error: 'X' is not a valid octal digit
+//     0oXYZ
+//       ^
+// 
 fn main() -> Int {
     0oXYZ
 }

--- a/tests/negative/lexer/string_byte1.orng
+++ b/tests/negative/lexer/string_byte1.orng
@@ -1,3 +1,7 @@
+// string_byte1.orng:6:17: error: 'Z' is not a valid hexadecimal digit
+//     let x = "\xZ0" // This is invalid because the first character of Z0 is not a valid hex digit
+//                ^
+// 
 fn main() -> Int {
     let x = "\xZ0" // This is invalid because the first character of Z0 is not a valid hex digit
     0

--- a/tests/negative/lexer/string_byte2.orng
+++ b/tests/negative/lexer/string_byte2.orng
@@ -1,3 +1,7 @@
+// string_byte2.orng:6:18: error: 'Z' is not a valid hexadecimal digit
+//     let x = "\x0Z" // This is invalid because the second character of 0Z is not a valid hex digit
+//                 ^
+// 
 fn main() -> Int {
     let x = "\x0Z" // This is invalid because the second character of 0Z is not a valid hex digit
     0

--- a/tests/negative/lexer/string_eof.orng
+++ b/tests/negative/lexer/string_eof.orng
@@ -1,2 +1,6 @@
+// string_eof.orng:6:46: error: expected `"`, got end-of-file
+//     let x = "this string doesn't have an end!
+//                                             ^
+// 
 fn main() -> Int {
     let x = "this string doesn't have an end!

--- a/tests/negative/lexer/string_escape_eof.orng
+++ b/tests/negative/lexer/string_escape_eof.orng
@@ -1,2 +1,6 @@
+// string_escape_eof.orng:6:47: error: expected a string, got end-of-file
+//     let x = "this string doesn't have an end!\
+//                                              ^
+// 
 fn main() -> Int {
     let x = "this string doesn't have an end!\

--- a/tests/negative/lexer/string_invalid.orng
+++ b/tests/negative/lexer/string_invalid.orng
@@ -1,3 +1,7 @@
+// string_invalid.orng:6:35: error: invalid escape sequence '\d'
+//     let x = "invalid escape! -> \d"
+//                                  ^
+// 
 fn main() -> Int {
     let x = "invalid escape! -> \d"
     0

--- a/tests/negative/lexer/underscore_end.orng
+++ b/tests/negative/lexer/underscore_end.orng
@@ -1,3 +1,7 @@
+// underscore_end.orng:6:11: error: identifiers may not end in an underscore
+//     let x_ = 0
+//          ^
+// 
 fn main() -> Int {
     let x_ = 0
     x_

--- a/tests/negative/misc/empty.orng
+++ b/tests/negative/misc/empty.orng
@@ -1,0 +1,2 @@
+// error: no main function found
+// 

--- a/tests/negative/misc/improper-module-name.orng
+++ b/tests/negative/misc/improper-module-name.orng
@@ -1,1 +1,3 @@
+// improper-module-name.orng: error: symbol `improper-module-name` has an improper module name
+// 
 fn main() -> Int { 0 }

--- a/tests/negative/optimizer/div_zero_float.orng
+++ b/tests/negative/optimizer/div_zero_float.orng
@@ -1,3 +1,7 @@
+// div_zero_float.orng:6:14: error: divide by 0.0
+//     1.0 / 0.0
+//             ^
+// 
 fn main() -> Float {
     1.0 / 0.0
 }

--- a/tests/negative/optimizer/div_zero_int.orng
+++ b/tests/negative/optimizer/div_zero_int.orng
@@ -1,3 +1,7 @@
+// div_zero_int.orng:6:10: error: divide by 0
+//     1 / 0
+//         ^
+// 
 fn main() -> Int {
     1 / 0
 }

--- a/tests/negative/optimizer/mod_zero.orng
+++ b/tests/negative/optimizer/mod_zero.orng
@@ -1,3 +1,7 @@
+// mod_zero.orng:6:10: error: divide by 0
+//     5 % 0
+//         ^
+// 
 fn main() -> Int {
     5 % 0
 }

--- a/tests/negative/parser/array_idx.orng
+++ b/tests/negative/parser/array_idx.orng
@@ -1,3 +1,7 @@
+// array_idx.orng:7:8: error: expected an expression here, got `)`
+//     x[)
+//       ^
+// 
 fn main() -> Int {
     let x: [3]Int = (0, 0, 0)
     x[)

--- a/tests/negative/parser/chained_comparison.orng
+++ b/tests/negative/parser/chained_comparison.orng
@@ -1,3 +1,7 @@
+// chained_comparison.orng:6:20: error: expected a semicolon or a newline here, got `>`
+//     let x = 4 > 5 > 6
+//                   ^
+// 
 fn main() -> Int {
     let x = 4 > 5 > 6
     if x {

--- a/tests/negative/parser/dyn_non_ident.orng
+++ b/tests/negative/parser/dyn_non_ident.orng
@@ -1,3 +1,7 @@
+// dyn_non_ident.orng:6:11: error: expected `identifier`, got `{`
+//     &dyn {Int}
+//          ^
+// 
 fn main() -> Int { 
     &dyn {Int}
 }

--- a/tests/negative/parser/expect.orng
+++ b/tests/negative/parser/expect.orng
@@ -1,3 +1,7 @@
+// expect.orng:6:10: error: expected a pattern expression here, got `5`
+//     let 5 = 3
+//         ^
+// 
 fn main() -> Int {
     let 5 = 3
 }

--- a/tests/negative/parser/expected_block.orng
+++ b/tests/negative/parser/expected_block.orng
@@ -1,1 +1,5 @@
+// expected_block.orng:5:19: error: expected `{`, got `3`
+// fn main() -> Int 3
+//                  ^
+// 
 fn main() -> Int 3

--- a/tests/negative/parser/expression.orng
+++ b/tests/negative/parser/expression.orng
@@ -1,1 +1,5 @@
+// expression.orng:5:19: error: expected an expression here, got `defer`
+// fn main() -> defer 4 {}
+//                  ^
+// 
 fn main() -> defer 4 {}

--- a/tests/negative/parser/if_semi.orng
+++ b/tests/negative/parser/if_semi.orng
@@ -1,3 +1,7 @@
+// if_semi.orng:6:22: error: expected a semicolon here, got `true`
+//     if let x = 4 true {}
+//                     ^
+// 
 fn main() -> Int {
     if let x = 4 true {}
     0

--- a/tests/negative/parser/missing_brace.orng
+++ b/tests/negative/parser/missing_brace.orng
@@ -1,1 +1,7 @@
+// missing_brace.orng:7:21: error: expected closing `}` to match opening `{` here, got `(EOF)`
+//                    ^
+// missing_brace.orng:7:19: note: opening `{` here:
+// fn main() -> Int {0
+//                  ^
+// 
 fn main() -> Int {0

--- a/tests/negative/parser/missing_newline.orng
+++ b/tests/negative/parser/missing_newline.orng
@@ -1,3 +1,7 @@
+// missing_newline.orng:6:18: error: expected a semicolon or a newline here, got `let`
+//     let x = 4 let y = 5
+//                 ^
+// 
 fn main() -> Int {
     let x = 4 let y = 5
 }

--- a/tests/negative/parser/paramlist.orng
+++ b/tests/negative/parser/paramlist.orng
@@ -1,1 +1,7 @@
+// paramlist.orng:7:10: error: expected closing `)` to match opening `(` here, got `(EOF)`
+//         ^
+// paramlist.orng:7:9: note: opening `(` here:
+// fn main(
+//        ^
+// 
 fn main(

--- a/tests/negative/parser/paramlist2.orng
+++ b/tests/negative/parser/paramlist2.orng
@@ -1,1 +1,5 @@
+// paramlist2.orng:5:50: error: error: expected a compile-time constant type, got function
+// fn a (x : Int, y: fn () -> Int {}, z: Int) -> Int {}
+//                                                 ^
+// 
 fn a (x : Int, y: fn () -> Int {}, z: Int) -> Int {}

--- a/tests/negative/parser/parens.orng
+++ b/tests/negative/parser/parens.orng
@@ -1,1 +1,7 @@
+// parens.orng:7:16: error: expected closing `)` to match opening `(` here, got `(EOF)`
+//               ^
+// parens.orng:7:15: note: opening `(` here:
+// fn main() -> (
+//              ^
+// 
 fn main() -> (

--- a/tests/negative/parser/postfix_rsquare.orng
+++ b/tests/negative/parser/postfix_rsquare.orng
@@ -1,3 +1,10 @@
+// postfix_rsquare.orng:10:9: error: expected closing `]` to match opening `[` here, got `)`
+//     x[3)
+//        ^
+// postfix_rsquare.orng:10:7: note: opening `[` here:
+//     x[3)
+//      ^
+// 
 fn main() -> Int {
     let x: [3]Int = (0, 0, 0)
     x[3)

--- a/tests/negative/parser/prefix_rsquare.orng
+++ b/tests/negative/parser/prefix_rsquare.orng
@@ -1,3 +1,10 @@
+// prefix_rsquare.orng:9:17: error: expected closing `]` to match opening `[` here, got `let`
+//     let x = [let y = 4]Int
+//                ^
+// prefix_rsquare.orng:9:14: note: opening `[` here:
+//     let x = [let y = 4]Int
+//             ^
+// 
 fn main() -> Int {
     let x = [let y = 4]Int
     0

--- a/tests/negative/parser/runtime_default.orng
+++ b/tests/negative/parser/runtime_default.orng
@@ -1,3 +1,8 @@
+// runtime_default.orng:7:46: error: default values must be compile-time known
+//     const My_Type: Type = (x: Int = get_four())
+//                                             ^
+// runtime_default.orng:7:46: note: consider wrapping with `comptime`
+// 
 fn main() -> Int {
     const My_Type: Type = (x: Int = get_four())
     let y: My_Type

--- a/tests/negative/parser/top_level.orng
+++ b/tests/negative/parser/top_level.orng
@@ -1,1 +1,5 @@
+// top_level.orng:5:4: error: expected `fn`, `trait`, `impl`, or `const` here, got `123`
+// 123
+//   ^
+// 
 123

--- a/tests/negative/parser/undefined.orng
+++ b/tests/negative/parser/undefined.orng
@@ -1,4 +1,7 @@
-// 343
+// undefined.orng:7:22: error: expected an expression here, got `undefined`
+//     let x = undefined
+//                     ^
+// 
 
 fn main() -> Int {
     let x = undefined

--- a/tests/negative/parser/unreachable_match.orng
+++ b/tests/negative/parser/unreachable_match.orng
@@ -1,3 +1,7 @@
+// unreachable_match.orng:7:20: error: expected an expression here, got `unreachable`
+//         unreachable => 35
+//                   ^
+// 
 fn main() -> Int {
     match 4 {
         unreachable => 35

--- a/tests/negative/parser/unrecognized_builtin.orng
+++ b/tests/negative/parser/unrecognized_builtin.orng
@@ -1,3 +1,7 @@
+// unrecognized_builtin.orng:6:18: error: unknown built-in function
+//     let x = @lmao(4)
+//                 ^
+// 
 fn main() -> Int {
     let x = @lmao(4)
     x

--- a/tests/negative/parser/untagged_arity.orng
+++ b/tests/negative/parser/untagged_arity.orng
@@ -1,1 +1,5 @@
+// untagged_arity.orng:5:42: error: built-in function takes 2 parameters, 0 arguments given
+// const My_Untagged_Union: Type = @Untagged()
+//                                         ^
+// 
 const My_Untagged_Union: Type = @Untagged()

--- a/tests/negative/parser/while_semi.orng
+++ b/tests/negative/parser/while_semi.orng
@@ -1,3 +1,7 @@
+// while_semi.orng:6:25: error: expected a semicolon here, got `true`
+//     while let x = 4 true {}
+//                        ^
+// 
 fn main() -> Int {
     while let x = 4 true {}
     0

--- a/tests/negative/pattern/mut_underscore.orng
+++ b/tests/negative/pattern/mut_underscore.orng
@@ -1,4 +1,4 @@
-// mut_underscore.orng:2:14: error: discarded symbol marked as `mut`
+// mut_underscore.orng:6:14: error: discarded symbol marked as `mut`
 //     let mut _ : Int = 4
 //             ^
 // 

--- a/tests/negative/pattern/mut_underscore.orng
+++ b/tests/negative/pattern/mut_underscore.orng
@@ -1,3 +1,7 @@
+// mut_underscore.orng:2:14: error: discarded symbol marked as `mut`
+//     let mut _ : Int = 4
+//             ^
+// 
 fn main() -> Int {
     let mut _ : Int = 4
     4

--- a/tests/negative/pattern/non_exhaustive_sum.orng
+++ b/tests/negative/pattern/non_exhaustive_sum.orng
@@ -1,3 +1,10 @@
+// non_exhaustive_sum.orng:4:10: error: match over sum type is not exhaustive
+//     match my_val {
+//         ^
+// non_exhaustive_sum.orng:2:34: note: term not handled: `d`
+//     const My_Sum = (a | b | c | d)
+//                                 ^
+// 
 fn main() -> Int {
     const My_Sum = (a | b | c | d)
     let my_val: My_Sum = .a

--- a/tests/negative/pattern/non_exhaustive_sum.orng
+++ b/tests/negative/pattern/non_exhaustive_sum.orng
@@ -1,7 +1,7 @@
-// non_exhaustive_sum.orng:4:10: error: match over sum type is not exhaustive
+// non_exhaustive_sum.orng:11:10: error: match over sum type is not exhaustive
 //     match my_val {
 //         ^
-// non_exhaustive_sum.orng:2:34: note: term not handled: `d`
+// non_exhaustive_sum.orng:9:34: note: term not handled: `d`
 //     const My_Sum = (a | b | c | d)
 //                                 ^
 // 

--- a/tests/negative/regression/r0.orng
+++ b/tests/negative/regression/r0.orng
@@ -1,1 +1,5 @@
+// r0.orng:5:12: error: left-hand-side of select is not selectable
+// const a: a.Float() = 0
+//           ^
+// 
 const a: a.Float() = 0

--- a/tests/negative/regression/r1.orng
+++ b/tests/negative/regression/r1.orng
@@ -1,1 +1,5 @@
+// r1.orng:5:12: error: error: expected a compile-time constant type, got function
+// fn () -> 0[-2]{}
+//           ^
+// 
 fn () -> 0[-2]{}

--- a/tests/negative/regression/r10.orng
+++ b/tests/negative/regression/r10.orng
@@ -1,3 +1,7 @@
+// r10.orng:6:14: error: attempt to take slice-of something that is not an array
+//     let a = []2
+//             ^
+// 
 fn main () -> () {
     let a = []2
     a

--- a/tests/negative/regression/r11.orng
+++ b/tests/negative/regression/r11.orng
@@ -1,3 +1,7 @@
+// r11.orng:6:8: error: expected a value of type `[*]String`, got a value of type `String`
+//     let (a, b, c): []String
+//       ^
+// 
 fn main()->() {
     let (a, b, c): []String
 }

--- a/tests/negative/regression/r12.orng
+++ b/tests/negative/regression/r12.orng
@@ -1,3 +1,10 @@
+// r12.orng:9:18: error: error: expected a compile-time constant type, got negate
+//     if const x: -x; true {}
+//                 ^
+// r12.orng:9:7: error: expected a value of type `Int`
+//     if const x: -x; true {}
+//      ^
+// 
 fn main() -> Int { 
     if const x: -x; true {}
 }

--- a/tests/negative/regression/r13.orng
+++ b/tests/negative/regression/r13.orng
@@ -1,1 +1,5 @@
+// r13.orng:5:26: error: expected a value of type `Int`, got a value of type `Void`
+// fn main() -> Int { return }
+//                         ^
+// 
 fn main() -> Int { return }

--- a/tests/negative/regression/r14.orng
+++ b/tests/negative/regression/r14.orng
@@ -1,3 +1,7 @@
+// r14.orng:6:18: error: not integer literal
+//     let mut x : [unreachable] Int
+//                 ^
+// 
 fn main() -> Int {
     let mut x : [unreachable] Int
     0

--- a/tests/negative/regression/r15.orng
+++ b/tests/negative/regression/r15.orng
@@ -1,3 +1,7 @@
+// r15.orng:6:19: error: expected a value of a(n) integer type, got `Float`
+//     errdefer 3.4 % unreachable * ? if - 4 { }
+//                  ^
+// 
 fn main() -> Int { 
     errdefer 3.4 % unreachable * ? if - 4 { }
 } 

--- a/tests/negative/regression/r16.orng
+++ b/tests/negative/regression/r16.orng
@@ -1,3 +1,7 @@
+// r16.orng:6:6: error: expected a value of type `Int`
+//     & mut ? if & mut [ ] & ? { } { }
+//     ^
+// 
 fn main ( ) -> Int { 
     & mut ? if & mut [ ] & ? { } { }
 } 

--- a/tests/negative/regression/r17.orng
+++ b/tests/negative/regression/r17.orng
@@ -1,1 +1,5 @@
+// r17.orng:5:28: error: error: expected a compile-time constant type, got negate
+// fn main() -> Int { let x: -2 = 43 } 
+//                           ^
+// 
 fn main() -> Int { let x: -2 = 43 } 

--- a/tests/negative/regression/r18.orng
+++ b/tests/negative/regression/r18.orng
@@ -1,1 +1,5 @@
+// r18.orng:5:15: error: error: expected a compile-time constant type, got while
+// const b: while let a: {break} = true; true { } = 0
+//              ^
+// 
 const b: while let a: {break} = true; true { } = 0

--- a/tests/negative/regression/r19.orng
+++ b/tests/negative/regression/r19.orng
@@ -1,3 +1,7 @@
+// r19.orng:6:13: error: error: expected a compile-time constant type, got slice_of
+//     let d: []{}
+//            ^
+// 
 fn main() -> () { 
     let d: []{}
     _ = d

--- a/tests/negative/regression/r2.orng
+++ b/tests/negative/regression/r2.orng
@@ -1,1 +1,5 @@
+// r2.orng:5:11: error: the type `Int` is not indexable
+// const a: 1[2]() = 0
+//          ^
+// 
 const a: 1[2]() = 0

--- a/tests/negative/regression/r20.orng
+++ b/tests/negative/regression/r20.orng
@@ -1,1 +1,5 @@
+// r20.orng:5:28: error: expected a value of type `Int`, got a value of type `Type`
+// fn main() -> Int { return []() }
+//                           ^
+// 
 fn main() -> Int { return []() }

--- a/tests/negative/regression/r21.orng
+++ b/tests/negative/regression/r21.orng
@@ -1,3 +1,4 @@
+// 
 fn main() -> Int { 
     const x = while true { } // This should trip the timeout for the interpreter
     4

--- a/tests/negative/regression/r22.orng
+++ b/tests/negative/regression/r22.orng
@@ -1,3 +1,7 @@
+// r22.orng:6:20: error: error: expected a compile-time constant type, got comptime
+//     const ident = { return }
+//                   ^
+// 
 fn main() -> Int { 
     const ident = { return }
 } 

--- a/tests/negative/regression/r23.orng
+++ b/tests/negative/regression/r23.orng
@@ -1,3 +1,7 @@
+// r23.orng:6:13: error: error: expected a compile-time constant type, got block
+//     let x: {Int}
+//            ^
+// 
 fn main() -> Int {
     let x: {Int}
     4

--- a/tests/negative/regression/r24.orng
+++ b/tests/negative/regression/r24.orng
@@ -1,3 +1,7 @@
+// r24.orng:6:14: error: error: expected a compile-time constant type, got sum_type
+//     let x: ?{Int}
+//             ^
+// 
 fn main() -> Int {
     let x: ?{Int}
     4

--- a/tests/negative/regression/r25.orng
+++ b/tests/negative/regression/r25.orng
@@ -1,3 +1,7 @@
+// r25.orng:7:40: error: cannot access non-const variable `ident` from an inner-function
+// fn (ident: Int) -> fn() -> (while ident {}) { } { 
+//                                       ^
+// 
 fn main() -> Int { } 
 
 fn (ident: Int) -> fn() -> (while ident {}) { } { 

--- a/tests/negative/regression/r26.orng
+++ b/tests/negative/regression/r26.orng
@@ -1,3 +1,7 @@
+// r26.orng:5:41: error: `break` is not inside a loop
+// fn ident ( ) -> ident .> ident ( { break } ) {
+//                                        ^
+// 
 fn ident ( ) -> ident .> ident ( { break } ) {
 
 } 

--- a/tests/negative/regression/r27.orng
+++ b/tests/negative/regression/r27.orng
@@ -1,3 +1,10 @@
+// r27.orng:9:28: error: error: expected a compile-time constant type, got while
+//     while let ident : while true ; impl for fn ( ) -> Int { } { } { } ; true { } 
+//                           ^
+// r27.orng:9:79: error: expected a value of type `Int`, got a value of type `()`
+//     while let ident : while true ; impl for fn ( ) -> Int { } { } { } ; true { } 
+//                                                                              ^
+// 
 fn main() -> Int { 
     while let ident : while true ; impl for fn ( ) -> Int { } { } { } ; true { } 
 }

--- a/tests/negative/regression/r28.orng
+++ b/tests/negative/regression/r28.orng
@@ -1,3 +1,7 @@
+// r28.orng:6:8: error: expected a value of type `Int`, got a value of type `()`
+//     let ident = while true ; impl main for comptime { } { } { }
+//       ^
+// 
 fn main() -> Int {
     let ident = while true ; impl main for comptime { } { } { }
 }

--- a/tests/negative/regression/r29.orng
+++ b/tests/negative/regression/r29.orng
@@ -1,3 +1,7 @@
+// r29.orng:6:14: error: error: expected a compile-time constant type, got block
+//     fn x(y: {Int}) -> ()
+//             ^
+// 
 trait A {
     fn x(y: {Int}) -> ()
 }

--- a/tests/negative/regression/r3.orng
+++ b/tests/negative/regression/r3.orng
@@ -1,1 +1,5 @@
+// r3.orng:5:15: error: error: expected a compile-time constant type, got while
+// const b: while let a: {break} = true; true { } = 0
+//              ^
+// 
 const b: while let a: {break} = true; true { } = 0

--- a/tests/negative/regression/r30.orng
+++ b/tests/negative/regression/r30.orng
@@ -1,3 +1,7 @@
+// r30.orng:6:20: error: error: expected a compile-time constant type, got comptime
+//     let x: comptime {?match () { _ => Int }}
+//                   ^
+// 
 fn main() -> Int { 
     let x: comptime {?match () { _ => Int }}
     x.some

--- a/tests/negative/regression/r31.orng
+++ b/tests/negative/regression/r31.orng
@@ -1,3 +1,7 @@
+// r31.orng:6:17: error: error: expected a compile-time constant type, got while
+//     let x: while true {Int}
+//                ^
+// 
 fn main() -> Int { 
     let x: while true {Int}
 }

--- a/tests/negative/regression/r32.orng
+++ b/tests/negative/regression/r32.orng
@@ -1,3 +1,7 @@
+// r32.orng:6:8: error: expected a value of type `Int`, got a value of type `()`
+//     let b = while true; impl for [] comptime {} {} {}
+//       ^
+// 
 fn main() -> Int { 
     let b = while true; impl for [] comptime {} {} {}
 } 

--- a/tests/negative/regression/r33.orng
+++ b/tests/negative/regression/r33.orng
@@ -1,3 +1,7 @@
+// r33.orng:6:29: error: error: recursive definition of symbol `main` detected
+//     main += match const main = main ; 4 { _ => 3 } 
+//                            ^
+// 
 fn main() -> Int { 
     main += match const main = main ; 4 { _ => 3 } 
 } 

--- a/tests/negative/regression/r34.orng
+++ b/tests/negative/regression/r34.orng
@@ -1,3 +1,7 @@
+// r34.orng:6:17: error: expected a value of type `Type`, got a value of type `()->Int`
+//     let a: &main
+//                ^
+// 
 fn main() -> Int {
     let a: &main
 } 

--- a/tests/negative/regression/r35.orng
+++ b/tests/negative/regression/r35.orng
@@ -1,3 +1,7 @@
+// r35.orng:8:18: error: expected a value of type `Type`, got a value of type `()->Int`
+//     impl for main { }
+//                 ^
+// 
 impl for () { } // The order matters here, this HAS to be first
 
 fn main() -> Int {

--- a/tests/negative/regression/r36.orng
+++ b/tests/negative/regression/r36.orng
@@ -1,1 +1,3 @@
+// error: no main function found
+// 
 impl for () { }

--- a/tests/negative/regression/r37.orng
+++ b/tests/negative/regression/r37.orng
@@ -1,3 +1,7 @@
+// r37.orng:5:20: error: error: expected a compile-time constant type, got if
+// impl for @sizeof(if () { }) { } 
+//                   ^
+// 
 impl for @sizeof(if () { }) { } 
 
 fn main() -> Int {0}

--- a/tests/negative/regression/r38.orng
+++ b/tests/negative/regression/r38.orng
@@ -1,3 +1,7 @@
+// r38.orng:6:33: error: no default value for type `()->()`
+//     const a: @typeof( fn () -> () { } )
+//                                ^
+// 
 fn main() -> Int { 
     const a: @typeof( fn () -> () { } )
 } 

--- a/tests/negative/regression/r39.orng
+++ b/tests/negative/regression/r39.orng
@@ -1,3 +1,8 @@
+// r39.orng:7:33: error: expected a value of type `()`, got a value of type `Int`
+//     const a: Int = match { } { 4 => 5 }
+//                                ^
+// error: comptime cannot be type `Void`
+// 
 fn main() -> Int { 
     const a: Int = match { } { 4 => 5 }
     a

--- a/tests/negative/regression/r4.orng
+++ b/tests/negative/regression/r4.orng
@@ -1,1 +1,5 @@
+// r4.orng:5:13: error: array length is not positive
+// fn b () -> [0]Float { }
+//            ^
+// 
 fn b () -> [0]Float { }

--- a/tests/negative/regression/r5.orng
+++ b/tests/negative/regression/r5.orng
@@ -1,1 +1,6 @@
+// r5.orng:6:20: error: expected a value of type `Bool`
+// const a: Bool = (0, []1)
+//                   ^
+// error: comptime cannot be type `Void`
+// 
 const a: Bool = (0, []1)

--- a/tests/negative/regression/r6.orng
+++ b/tests/negative/regression/r6.orng
@@ -1,1 +1,5 @@
+// r6.orng:5:20: error: error: expected a compile-time constant type, got function
+// fn () -> (_ = Bool, _ = String) {}
+//                   ^
+// 
 fn () -> (_ = Bool, _ = String) {}

--- a/tests/negative/regression/r7.orng
+++ b/tests/negative/regression/r7.orng
@@ -1,1 +1,5 @@
+// r7.orng:5:12: error: error: expected a compile-time constant type, got function
+// fn ( ) -> & { _ = (main : [ ] Char) } {}
+//           ^
+// 
 fn ( ) -> & { _ = (main : [ ] Char) } {}

--- a/tests/negative/regression/r8.orng
+++ b/tests/negative/regression/r8.orng
@@ -1,1 +1,5 @@
+// r8.orng:5:44: error: error: expected a compile-time constant type, got sum_type
+// const a : ? ( _ = Float , _ = Float ) . b . String = a 
+//                                           ^
+// 
 const a : ? ( _ = Float , _ = Float ) . b . String = a 

--- a/tests/negative/regression/r9.orng
+++ b/tests/negative/regression/r9.orng
@@ -1,1 +1,5 @@
+// r9.orng:5:22: error: error: expected a compile-time constant type, got unreachable
+// const x : unreachable = 3
+//                     ^
+// 
 const x : unreachable = 3

--- a/tests/negative/symbols/capture.orng
+++ b/tests/negative/symbols/capture.orng
@@ -1,3 +1,7 @@
+// capture.orng:8:10: error: cannot access non-const variable `x` from an inner-function
+//         x
+//         ^
+// 
 fn main() -> Int {
     let x: Int = 45
     fn f() -> Int {

--- a/tests/negative/symbols/fn_redef.orng
+++ b/tests/negative/symbols/fn_redef.orng
@@ -1,3 +1,10 @@
+// fn_redef.orng:10:9: error: redefinition of symbol `x`
+//     fn x()->(){}
+//        ^
+// fn_redef.orng:9:10: note: other definition of `x` here:
+//     let x = 0
+//         ^
+// 
 fn main() -> Int {
     let x = 0
     fn x()->(){}

--- a/tests/negative/symbols/immutable_ident.orng
+++ b/tests/negative/symbols/immutable_ident.orng
@@ -1,3 +1,7 @@
+// immutable_ident.orng:7:6: error: cannot modify non-mutable symbol `x`
+//     x = 4
+//     ^
+// 
 fn main() -> Int {
     let x = 0
     x = 4

--- a/tests/negative/symbols/lowercase_type.orng
+++ b/tests/negative/symbols/lowercase_type.orng
@@ -1,3 +1,7 @@
+// lowercase_type.orng:5:10: error: symbol `int` of type `Type` must start with an uppercase letter
+// const int: Type = (a: Int, b: Int)
+//         ^
+// 
 const int: Type = (a: Int, b: Int)
 
 fn main() -> Int {

--- a/tests/negative/symbols/misspelled.orng
+++ b/tests/negative/symbols/misspelled.orng
@@ -1,3 +1,7 @@
+// misspelled.orng:9:8: error: use of undeclared identifier `car`
+//     car
+//       ^
+// 
 fn main() -> Int {
     let var = 4
     let bar = 5

--- a/tests/negative/symbols/recursive.orng
+++ b/tests/negative/symbols/recursive.orng
@@ -1,3 +1,5 @@
+// error: use of identifier `x` before its definition
+// 
 fn main() -> Int  {
     let x = x
     0

--- a/tests/negative/symbols/redef.orng
+++ b/tests/negative/symbols/redef.orng
@@ -1,3 +1,10 @@
+// redef.orng:10:10: error: redefinition of symbol `x`
+//     let x = 4
+//         ^
+// redef.orng:9:10: note: other definition of `x` here:
+//     let x = 0
+//         ^
+// 
 fn main() -> Int {
     let x = 0
     let x = 4

--- a/tests/negative/symbols/undeclared.orng
+++ b/tests/negative/symbols/undeclared.orng
@@ -1,3 +1,7 @@
+// undeclared.orng:6:15: error: use of undeclared identifier `googoogaga`
+//     googoogaga
+//              ^
+// 
 fn main() -> Int {
     googoogaga
 }

--- a/tests/negative/symbols/undefined.orng
+++ b/tests/negative/symbols/undefined.orng
@@ -1,3 +1,5 @@
+// error: use of identifier `x` before its definition
+// 
 fn main() -> Int {
     let y = x
     let x = 0

--- a/tests/negative/symbols/unused.orng
+++ b/tests/negative/symbols/unused.orng
@@ -1,3 +1,7 @@
+// unused.orng:6:10: error: symbol `x` is never used
+//     let x = 132
+//         ^
+// 
 fn main() -> Int {
     let x = 132
     1

--- a/tests/negative/symbols/unused_call.orng
+++ b/tests/negative/symbols/unused_call.orng
@@ -1,3 +1,7 @@
+// unused_call.orng:7:7: error: expected a value of type `()`, got a value of type `Int`
+//     f()
+//      ^
+// 
 fn main() -> Int {
     _ = f()
     f()

--- a/tests/negative/symbols/unused_param.orng
+++ b/tests/negative/symbols/unused_param.orng
@@ -1,3 +1,7 @@
+// unused_param.orng:9:10: error: symbol `x` is never used
+// fn test(x: Int, y: Int) -> Int {
+//         ^
+// 
 fn main() -> Int {
     test(3, 4)
 }

--- a/tests/negative/symbols/uppercase_fn.orng
+++ b/tests/negative/symbols/uppercase_fn.orng
@@ -1,1 +1,5 @@
+// uppercase_fn.orng:5:7: error: symbol `Lol` of type other than `Type` must start with a lowercase letter
+// fn Lol() -> Int { 4 }
+//      ^
+// 
 fn Lol() -> Int { 4 }

--- a/tests/negative/symbols/uppercase_value.orng
+++ b/tests/negative/symbols/uppercase_value.orng
@@ -1,3 +1,7 @@
+// uppercase_value.orng:6:10: error: symbol `X` of type other than `Type` must start with a lowercase letter
+//     let X = 4
+//         ^
+// 
 fn main() -> Int {
     let X = 4
     X

--- a/tests/negative/symbols/use_undef.orng
+++ b/tests/negative/symbols/use_undef.orng
@@ -1,3 +1,10 @@
+// use_undef.orng:8:8: error: symbol `x` is never defined
+// fn main() -> Int {
+//       ^
+// use_undef.orng:9:10: note: declared here
+//     let x: Int = undefined
+//         ^
+// 
 fn main() -> Int {
     let x: Int = undefined
     x

--- a/tests/negative/symbols/use_undef2.orng
+++ b/tests/negative/symbols/use_undef2.orng
@@ -1,3 +1,10 @@
+// use_undef2.orng:10:8: error: symbol `x` is never defined
+//     4 + x
+//       ^
+// use_undef2.orng:9:10: note: declared here
+//     let x: Int = undefined
+//         ^
+// 
 fn main() -> Int {
     let x: Int = undefined
     4 + x

--- a/tests/negative/symbols/use_undef3.orng
+++ b/tests/negative/symbols/use_undef3.orng
@@ -1,3 +1,10 @@
+// use_undef3.orng:10:9: error: symbol `x` is never defined
+//     add(4, x)
+//        ^
+// use_undef3.orng:9:10: note: declared here
+//     let x: Int = undefined
+//         ^
+// 
 fn main() -> Int {
     let x: Int = undefined
     add(4, x)

--- a/tests/negative/symbols/use_undef4.orng
+++ b/tests/negative/symbols/use_undef4.orng
@@ -1,3 +1,10 @@
+// use_undef4.orng:14:8: error: symbol `x` is never defined
+//     x.>add(4)
+//       ^
+// use_undef4.orng:13:10: note: declared here
+//     let x: &dyn Add = undefined
+//         ^
+// 
 trait Add {
     virtual fn add(&self, other: Int) -> Int
 }

--- a/tests/negative/symbols/use_undef5.orng
+++ b/tests/negative/symbols/use_undef5.orng
@@ -1,3 +1,10 @@
+// use_undef5.orng:15:8: error: symbol `x` is never defined
+//     y.>add(x)
+//       ^
+// use_undef5.orng:13:10: note: declared here
+//     let x: Int = undefined
+//         ^
+// 
 impl for Int {
     fn add(self, other: Int) -> Int { self + other }
 }

--- a/tests/negative/symbols/use_undef6.orng
+++ b/tests/negative/symbols/use_undef6.orng
@@ -1,3 +1,10 @@
+// use_undef6.orng:8:8: error: symbol `x` is never defined
+// fn main() -> Int {
+//       ^
+// use_undef6.orng:9:10: note: declared here
+//     let x: [4]Int = undefined
+//         ^
+// 
 fn main() -> Int {
     let x: [4]Int = undefined
     x[2]

--- a/tests/negative/traits/duplicate_empty.orng
+++ b/tests/negative/traits/duplicate_empty.orng
@@ -1,9 +1,0 @@
-// error: no main function found
-// 
-impl for Int {
-    fn f(self) -> Int { self }
-}
-
-impl for Int {
-    fn g(&self) -> Int { self^ }
-}

--- a/tests/negative/traits/duplicate_empty.orng
+++ b/tests/negative/traits/duplicate_empty.orng
@@ -1,3 +1,5 @@
+// error: no main function found
+// 
 impl for Int {
     fn f(self) -> Int { self }
 }

--- a/tests/negative/traits/duplicate_method.orng
+++ b/tests/negative/traits/duplicate_method.orng
@@ -1,3 +1,10 @@
+// duplicate_method.orng:10:7: error: duplicate item `lol`
+//     fn lol() -> ()
+//      ^
+// duplicate_method.orng:9:7: note: other definition of `lol` here:
+//     fn lol() -> ()
+//      ^
+// 
 trait My_Trait {
     fn lol() -> ()
     fn lol() -> ()

--- a/tests/negative/traits/dyn_type_not_impl_trait.orng
+++ b/tests/negative/traits/dyn_type_not_impl_trait.orng
@@ -1,3 +1,7 @@
+// dyn_type_not_impl_trait.orng:11:8: error: the type `Int` does not implement the trait `Lol`
+//     f(&x)
+//       ^
+// 
 trait Lol {
     fn lol() -> ()
 }

--- a/tests/negative/traits/impl_for_addr.orng
+++ b/tests/negative/traits/impl_for_addr.orng
@@ -1,3 +1,7 @@
+// impl_for_addr.orng:5:11: error: cannot implement method for address types
+// impl for &mut Int {
+//          ^
+// 
 impl for &mut Int {
     fn a (self, x: Int) -> () {self^ += x}
 }

--- a/tests/negative/traits/invoke_addr_method_not_found.orng
+++ b/tests/negative/traits/invoke_addr_method_not_found.orng
@@ -1,3 +1,7 @@
+// invoke_addr_method_not_found.orng:8:8: error: the type `&Int` does not implement the method `add`
+//     y.>add(56)
+//       ^
+// 
 fn main() -> Int {
     let x = 4
     let y = &x

--- a/tests/negative/traits/invoke_addr_mutability.orng
+++ b/tests/negative/traits/invoke_addr_mutability.orng
@@ -1,3 +1,7 @@
+// invoke_addr_mutability.orng:18:6: error: receiver `&mut self` of method `lmao` incompatible with type `&Int`
+//     y.>lmao()
+//     ^
+// 
 trait Lol {
     fn lmao(&mut self) -> ()
 }

--- a/tests/negative/traits/invoke_dyn_method_not_found.orng
+++ b/tests/negative/traits/invoke_dyn_method_not_found.orng
@@ -1,3 +1,7 @@
+// invoke_dyn_method_not_found.orng:15:8: error: the type `&dyn My_Trait` does not implement the method `get_int`
+//     x.>get_int()
+//       ^
+// 
 trait My_Trait { }
 
 impl My_Trait for Int { }

--- a/tests/negative/traits/invoke_dyn_mutability.orng
+++ b/tests/negative/traits/invoke_dyn_mutability.orng
@@ -1,3 +1,7 @@
+// invoke_dyn_mutability.orng:21:6: error: receiver `&mut self` of method `lmao` incompatible with type `&dyn Lol`
+//     x.>lmao()
+//     ^
+// 
 trait Lol {
     fn lmao(&mut self) -> ()
 }

--- a/tests/negative/traits/invoke_static_method_not_found.orng
+++ b/tests/negative/traits/invoke_static_method_not_found.orng
@@ -1,3 +1,7 @@
+// invoke_static_method_not_found.orng:7:8: error: the type `Int` does not implement the method `add`
+//     x.>add(56)
+//       ^
+// 
 fn main() -> Int {
     let x = 4
     x.>add(56)

--- a/tests/negative/traits/method_not_in_empty_impl.orng
+++ b/tests/negative/traits/method_not_in_empty_impl.orng
@@ -1,3 +1,10 @@
+// method_not_in_empty_impl.orng:12:5: error: missing implementation of method `f` from trait `My_Trait`
+// impl My_Trait for Int {}
+//    ^
+// method_not_in_empty_impl.orng:9:7: note: method specification here:
+//     fn f() -> ()
+//      ^
+// 
 trait My_Trait {
     fn f() -> ()
 }

--- a/tests/negative/traits/method_not_in_empty_trait.orng
+++ b/tests/negative/traits/method_not_in_empty_trait.orng
@@ -1,3 +1,7 @@
+// method_not_in_empty_trait.orng:8:7: error: method `f` is not in trait `My_Trait`
+//     fn f() -> () { }
+//      ^
+// 
 trait My_Trait { }
 
 impl My_Trait for Int {

--- a/tests/negative/traits/method_not_in_impl.orng
+++ b/tests/negative/traits/method_not_in_impl.orng
@@ -1,3 +1,10 @@
+// method_not_in_impl.orng:14:5: error: missing implementation of method `f` from trait `My_Trait`
+// impl My_Trait for Int {
+//    ^
+// method_not_in_impl.orng:9:7: note: method specification here:
+//     fn f() -> ()
+//      ^
+// 
 trait My_Trait {
     fn f() -> ()
 

--- a/tests/negative/traits/method_not_in_trait.orng
+++ b/tests/negative/traits/method_not_in_trait.orng
@@ -1,3 +1,7 @@
+// method_not_in_trait.orng:10:7: error: method `f` is not in trait `My_Trait`
+//     fn f() -> () { }
+//      ^
+// 
 trait My_Trait { 
     fn g() -> ()
 }

--- a/tests/negative/traits/method_receiver_empty_init.orng
+++ b/tests/negative/traits/method_receiver_empty_init.orng
@@ -1,4 +1,7 @@
-// 289
+// method_receiver_empty_init.orng:12:14: error: symbol `self` is never used
+//     fn a(self) -> () {  }
+//             ^
+// 
 trait My_Trait {
     fn a(self) -> ()
 }

--- a/tests/negative/traits/mismatch_method_param_arity.orng
+++ b/tests/negative/traits/mismatch_method_param_arity.orng
@@ -1,3 +1,7 @@
+// mismatch_method_param_arity.orng:10:7: error: trait `My_Trait` specifies 1 parameter for method `f`, got 2
+//     fn f(self, x: Int) -> () {}
+//      ^
+// 
 trait My_Trait {
     fn f(self) -> ()
 }

--- a/tests/negative/traits/mismatch_param_type.orng
+++ b/tests/negative/traits/mismatch_param_type.orng
@@ -1,3 +1,7 @@
+// mismatch_param_type.orng:10:23: error: trait `My_Trait` specifies type `Int` for method `f`, got `Char`
+//     fn f(self, x: Char) -> () {}
+//                      ^
+// 
 trait My_Trait {
     fn f(self, x: Int) -> ()
 }

--- a/tests/negative/traits/mismatch_receiver.orng
+++ b/tests/negative/traits/mismatch_receiver.orng
@@ -1,3 +1,7 @@
+// mismatch_receiver.orng:10:15: error: trait `My_Trait` specifies receiver `self` for method `f`, got receiver `&self`
+//     fn f(&self) -> () {}
+//              ^
+// 
 trait My_Trait {
     fn f(self) -> ()
 }

--- a/tests/negative/traits/mismatch_receiver_extra.orng
+++ b/tests/negative/traits/mismatch_receiver_extra.orng
@@ -1,3 +1,7 @@
+// mismatch_receiver_extra.orng:10:14: error: trait `My_Trait` does not specify a receiver for method `f`, got receiver `self`
+//     fn f(self) -> () {}
+//             ^
+// 
 trait My_Trait {
     fn f() -> ()
 }

--- a/tests/negative/traits/mismatch_receiver_missing.orng
+++ b/tests/negative/traits/mismatch_receiver_missing.orng
@@ -1,3 +1,7 @@
+// mismatch_receiver_missing.orng:10:7: error: trait `My_Trait` specifies receiver `self` for method `f`
+//     fn f() -> () {}
+//      ^
+// 
 trait My_Trait {
     fn f(self) -> ()
 }

--- a/tests/negative/traits/mismatch_return_type.orng
+++ b/tests/negative/traits/mismatch_return_type.orng
@@ -1,3 +1,7 @@
+// mismatch_return_type.orng:10:20: error: trait `My_Trait` specifies type `Int` for method `f`, got `()`
+//     fn f(self) -> () {}
+//                   ^
+// 
 trait My_Trait {
     fn f(self) -> Int
 }

--- a/tests/negative/traits/mismatch_virtuality.orng
+++ b/tests/negative/traits/mismatch_virtuality.orng
@@ -1,3 +1,7 @@
+// mismatch_virtuality.orng:10:7: error: trait `Lol` specifies the method `lmao` as virtual, got non-virtual
+//     fn lmao(&mut self) -> () {
+//      ^
+// 
 trait Lol {
     virtual fn lmao(&mut self) -> ()
 }

--- a/tests/negative/traits/reimpl.orng
+++ b/tests/negative/traits/reimpl.orng
@@ -1,3 +1,10 @@
+// reimpl.orng:10:5: error: duplicate implementation of trait `My_Trait` for the type `Int`
+// impl My_Trait for Int {}
+//    ^
+// reimpl.orng:10:5: note: other implementation of `My_Trait` here:
+// impl My_Trait for Int {}
+//    ^
+// 
 trait My_Trait {}
 
 impl My_Trait for Int {}

--- a/tests/negative/traits/virtual_params_refers_to_self.orng
+++ b/tests/negative/traits/virtual_params_refers_to_self.orng
@@ -1,3 +1,7 @@
+// virtual_params_refers_to_self.orng:6:15: error: virtual method `lol` of trait `Lol` refers to `Self` type
+//     virtual fn lol(x: Self, y: Self) -> ()
+//              ^
+// 
 trait Lol {
     virtual fn lol(x: Self, y: Self) -> ()
 }

--- a/tests/negative/traits/virtual_return_refers_to_self.orng
+++ b/tests/negative/traits/virtual_return_refers_to_self.orng
@@ -1,3 +1,7 @@
+// virtual_return_refers_to_self.orng:6:15: error: virtual method `lol` of trait `Lol` refers to `Self` type
+//     virtual fn lol() -> Self
+//              ^
+// 
 trait Lol {
     virtual fn lol() -> Self
 }

--- a/tests/negative/typecheck/add.orng
+++ b/tests/negative/typecheck/add.orng
@@ -1,1 +1,5 @@
+// add.orng:5:19: error: expected a value of type `Char`, got a value of type `Int`
+// fn main()->Char {4 + 5}
+//                  ^
+// 
 fn main()->Char {4 + 5}

--- a/tests/negative/typecheck/addr_val.orng
+++ b/tests/negative/typecheck/addr_val.orng
@@ -1,3 +1,7 @@
+// addr_val.orng:7:22: error: expected a value of type `Char`, got a value of type `Int`
+//     let y: &Char = &x
+//                     ^
+// 
 fn main() -> Int {
     let x = 0
     let y: &Char = &x

--- a/tests/negative/typecheck/addrof.orng
+++ b/tests/negative/typecheck/addrof.orng
@@ -1,1 +1,5 @@
+// addrof.orng:5:20: error: expected a value of type `Int`
+// fn main() -> Int {&Int}
+//                   ^
+// 
 fn main() -> Int {&Int}

--- a/tests/negative/typecheck/addrof_poison.orng
+++ b/tests/negative/typecheck/addrof_poison.orng
@@ -1,3 +1,7 @@
+// addrof_poison.orng:6:8: error: expected address type for dereference, got `Int`
+//     &(0^)
+//       ^
+// 
 fn main() -> Int  {
     &(0^)
     0

--- a/tests/negative/typecheck/addrof_type.orng
+++ b/tests/negative/typecheck/addrof_type.orng
@@ -1,3 +1,7 @@
+// addrof_type.orng:6:22: error: error: expected a compile-time constant type, got addr_of
+//     const X: Type = &4
+//                     ^
+// 
 fn main() -> Int {
     const X: Type = &4
     0

--- a/tests/negative/typecheck/and.orng
+++ b/tests/negative/typecheck/and.orng
@@ -1,1 +1,5 @@
+// and.orng:5:25: error: expected a value of type `Int`, got a value of type `Bool`
+// fn main()->Int {true and false}
+//                        ^
+// 
 fn main()->Int {true and false}

--- a/tests/negative/typecheck/annotation.orng
+++ b/tests/negative/typecheck/annotation.orng
@@ -1,3 +1,7 @@
+// annotation.orng:6:21: error: expected a value of type `Int`, got a value of type `Type`
+//     let x: Int = (a: Int)
+//                    ^
+// 
 fn main() -> Int {
     let x: Int = (a: Int)
     0

--- a/tests/negative/typecheck/annotation_not_ident.orng
+++ b/tests/negative/typecheck/annotation_not_ident.orng
@@ -1,3 +1,13 @@
+// annotation_not_ident.orng:12:24: error: expected identifier, got `a`
+//     const My_Type = (.a: Int | .b: Int | .c: Int)
+//                       ^
+// annotation_not_ident.orng:12:34: error: expected identifier, got `b`
+//     const My_Type = (.a: Int | .b: Int | .c: Int)
+//                                 ^
+// annotation_not_ident.orng:12:44: error: expected identifier, got `c`
+//     const My_Type = (.a: Int | .b: Int | .c: Int)
+//                                           ^
+// 
 fn main() -> Int {
     const My_Type = (.a: Int | .b: Int | .c: Int)
     4

--- a/tests/negative/typecheck/anon_fn.orng
+++ b/tests/negative/typecheck/anon_fn.orng
@@ -1,3 +1,7 @@
+// anon_fn.orng:6:20: error: expected a value of type `Int`, got a value of type `()->()`
+//     let x: Int = fn ()->() {}
+//                   ^
+// 
 fn main() -> Int {
     let x: Int = fn ()->() {}
     0

--- a/tests/negative/typecheck/arg_named_not_annot.orng
+++ b/tests/negative/typecheck/arg_named_not_annot.orng
@@ -1,3 +1,10 @@
+// arg_named_not_annot.orng:10:9: error: expected an inferred member, got `[`
+//     f(y[2] = 5)
+//        ^
+// arg_named_not_annot.orng:10:13: error: expected a value of type `Int`, got a value of type `()`
+//     f(y[2] = 5)
+//            ^
+// 
 fn main() -> Int {
     let mut y: [2]Int
     f(y[2] = 5)

--- a/tests/negative/typecheck/arg_named_too_many.orng
+++ b/tests/negative/typecheck/arg_named_too_many.orng
@@ -1,3 +1,10 @@
+// arg_named_too_many.orng:9:11: error: function takes 1 parameter, 2 arguments given
+//     f(.x = 4, .y = 4)
+//          ^
+// arg_named_too_many.orng:9:7: error: function takes 1 parameter, 2 arguments given
+//     f(.x = 4, .y = 4)
+//      ^
+// 
 fn main() -> Int {
     f(.x = 4, .y = 4)
 }

--- a/tests/negative/typecheck/args_few.orng
+++ b/tests/negative/typecheck/args_few.orng
@@ -1,3 +1,7 @@
+// args_few.orng:6:23: error: expected a value of type `Int`, got a value of type `Type`
+//     let x: (b:Int) = ()
+//                      ^
+// 
 fn main() -> Int {
     let x: (b:Int) = ()
     4

--- a/tests/negative/typecheck/args_mix.orng
+++ b/tests/negative/typecheck/args_mix.orng
@@ -1,3 +1,7 @@
+// args_mix.orng:6:36: error: mixed positional and named arguments are not allowed
+//     let x: (x: Int, y: Int) = (.x = 4, 5)
+//                                   ^
+// 
 fn main() -> Int {
     let x: (x: Int, y: Int) = (.x = 4, 5)
     x.x

--- a/tests/negative/typecheck/args_named_annot.orng
+++ b/tests/negative/typecheck/args_named_annot.orng
@@ -1,3 +1,7 @@
+// args_named_annot.orng:6:31: error: expected a value of type `Int`
+//     let x: (a: Int) = (.a = 4, .b = 4)
+//                              ^
+// 
 fn main() -> Int {
     let x: (a: Int) = (.a = 4, .b = 4)
     0

--- a/tests/negative/typecheck/args_named_dup.orng
+++ b/tests/negative/typecheck/args_named_dup.orng
@@ -1,3 +1,7 @@
+// args_named_dup.orng:6:44: error: duplicate item `a`
+//     let x: (a: Int, b: Int) = (.a = 4, .a = 5, .b = 4)
+//                                           ^
+// 
 fn main() -> Int {
     let x: (a: Int, b: Int) = (.a = 4, .a = 5, .b = 4)
     0

--- a/tests/negative/typecheck/args_named_few.orng
+++ b/tests/negative/typecheck/args_named_few.orng
@@ -1,3 +1,7 @@
+// args_named_few.orng:6:34: error: cannot infer the sum type
+//     let x: (a: Int, b: Int) = (.a = 43)
+//                                 ^
+// 
 fn main() -> Int {
     let x: (a: Int, b: Int) = (.a = 43)
     4

--- a/tests/negative/typecheck/args_named_few_named.orng
+++ b/tests/negative/typecheck/args_named_few_named.orng
@@ -1,3 +1,10 @@
+// args_named_few_named.orng:9:11: error: type takes 2 values, 1 value given
+//     f(.y = 5)
+//          ^
+// args_named_few_named.orng:9:7: error: function takes 2 parameters, 1 argument given
+//     f(.y = 5)
+//      ^
+// 
 fn main() -> Int {
     f(.y = 5)
 }

--- a/tests/negative/typecheck/args_named_not.orng
+++ b/tests/negative/typecheck/args_named_not.orng
@@ -1,3 +1,13 @@
+// args_named_not.orng:12:30: error: expected type does not accept named arugments
+//     let x: (Int, Int) = (.a = 4, .b = 4)
+//                             ^
+// args_named_not.orng:12:28: error: cannot infer the sum type
+//     let x: (Int, Int) = (.a = 4, .b = 4)
+//                           ^
+// args_named_not.orng:12:36: error: cannot infer the sum type
+//     let x: (Int, Int) = (.a = 4, .b = 4)
+//                                   ^
+// 
 fn main() -> Int {
     let x: (Int, Int) = (.a = 4, .b = 4)
     0

--- a/tests/negative/typecheck/args_named_not_annot.orng
+++ b/tests/negative/typecheck/args_named_not_annot.orng
@@ -1,3 +1,13 @@
+// args_named_not_annot.orng:13:9: error: expected an inferred member, got `[`
+//     f(y[2] = 5, y[2] = 5)
+//        ^
+// args_named_not_annot.orng:13:13: error: expected a value of type `Int`, got a value of type `()`
+//     f(y[2] = 5, y[2] = 5)
+//            ^
+// args_named_not_annot.orng:13:23: error: expected a value of type `Int`, got a value of type `()`
+//     f(y[2] = 5, y[2] = 5)
+//                      ^
+// 
 fn main() -> Int {
     let mut y: [2]Int
     f(y[2] = 5, y[2] = 5)

--- a/tests/negative/typecheck/args_named_zero.orng
+++ b/tests/negative/typecheck/args_named_zero.orng
@@ -1,3 +1,7 @@
+// args_named_zero.orng:6:7: error: function takes 0 parameters, 1 argument given
+//     f(.x = 4)
+//      ^
+// 
 fn main() -> Int { 
     f(.x = 4)
 }

--- a/tests/negative/typecheck/array.orng
+++ b/tests/negative/typecheck/array.orng
@@ -1,3 +1,7 @@
+// array.orng:7:7: error: expected a value of type `Int`, got a value of type `Char`
+//     x[1]
+//      ^
+// 
 fn main() -> Int {
     let x: [3]Char = ('1', '2', '3')
     x[1]

--- a/tests/negative/typecheck/block.orng
+++ b/tests/negative/typecheck/block.orng
@@ -1,1 +1,5 @@
+// block.orng:5:19: error: expected a value of type `Int`, got a value of type `()`
+// fn main() -> Int {}
+//                  ^
+// 
 fn main() -> Int {}

--- a/tests/negative/typecheck/break.orng
+++ b/tests/negative/typecheck/break.orng
@@ -1,3 +1,7 @@
+// break.orng:6:10: error: `break` is not inside a loop
+//     break
+//         ^
+// 
 fn main() -> Int {
     break
 }

--- a/tests/negative/typecheck/call.orng
+++ b/tests/negative/typecheck/call.orng
@@ -1,3 +1,7 @@
+// call.orng:5:21: error: expected a value of type `Int`, got a value of type `Char`
+// fn main() -> Int {f()}
+//                    ^
+// 
 fn main() -> Int {f()}
 
 fn f()->Char {'d'}

--- a/tests/negative/typecheck/call_non_fn.orng
+++ b/tests/negative/typecheck/call_non_fn.orng
@@ -1,3 +1,7 @@
+// call_non_fn.orng:7:6: error: expected function type for call, got `Int`
+//     x()
+//     ^
+// 
 fn main() -> Int {
     let x = 4
     x()

--- a/tests/negative/typecheck/catch.orng
+++ b/tests/negative/typecheck/catch.orng
@@ -1,3 +1,7 @@
+// catch.orng:7:12: error: expected a value of type `Int`, got a value of type `Char`
+//     x catch 4
+//           ^
+// 
 fn main() -> Int {
     let x: ()!Char = .ok('4')
     x catch 4

--- a/tests/negative/typecheck/catch_non_err.orng
+++ b/tests/negative/typecheck/catch_non_err.orng
@@ -1,3 +1,7 @@
+// catch_non_err.orng:6:6: error: expected error type for catch, got `Int`
+//     4 catch 5
+//     ^
+// 
 fn main() -> Int {
     4 catch 5
 }

--- a/tests/negative/typecheck/char.orng
+++ b/tests/negative/typecheck/char.orng
@@ -1,1 +1,5 @@
+// char.orng:5:22: error: expected a value of type `Int`, got a value of type `Char`
+// fn main() -> Int {'d'}
+//                     ^
+// 
 fn main() -> Int {'d'}

--- a/tests/negative/typecheck/conditional.orng
+++ b/tests/negative/typecheck/conditional.orng
@@ -1,1 +1,5 @@
+// conditional.orng:5:22: error: expected a value of type `Int`, got a value of type `Bool`
+// fn main() -> Int {0 < 1}
+//                     ^
+// 
 fn main() -> Int {0 < 1}

--- a/tests/negative/typecheck/continue.orng
+++ b/tests/negative/typecheck/continue.orng
@@ -1,3 +1,7 @@
+// continue.orng:6:13: error: `continue` is not inside a loop
+//     continue
+//            ^
+// 
 fn main() -> Int {
     continue
 }

--- a/tests/negative/typecheck/cyclic.orng
+++ b/tests/negative/typecheck/cyclic.orng
@@ -1,3 +1,7 @@
+// cyclic.orng:6:17: error: error: recursive definition detected
+// const B = (x: A, y: Int)
+//                ^
+// 
 const A = (x: B, y: Int)
 const B = (x: A, y: Int)
 

--- a/tests/negative/typecheck/decl.orng
+++ b/tests/negative/typecheck/decl.orng
@@ -1,3 +1,7 @@
+// decl.orng:6:8: error: expected a value of type `Int`, got a value of type `()`
+//     let x = 4
+//       ^
+// 
 fn main() -> Int {
     let x = 4
 }

--- a/tests/negative/typecheck/deref.orng
+++ b/tests/negative/typecheck/deref.orng
@@ -1,3 +1,7 @@
+// deref.orng:6:6: error: expected address type for dereference, got `Int`
+//     0^
+//     ^
+// 
 fn main () -> Int {
     0^
     0

--- a/tests/negative/typecheck/div.orng
+++ b/tests/negative/typecheck/div.orng
@@ -1,1 +1,5 @@
+// div.orng:5:19: error: expected a value of type `Char`, got a value of type `Int`
+// fn main()->Char {4 / 5}
+//                  ^
+// 
 fn main()->Char {4 / 5}

--- a/tests/negative/typecheck/dyn_type.orng
+++ b/tests/negative/typecheck/dyn_type.orng
@@ -1,3 +1,7 @@
+// dyn_type.orng:6:20: error: expected trait type for dyn, got `Int`
+//     let x: &dyn Int = 4
+//                   ^
+// 
 fn main() -> Int {
     let x: &dyn Int = 4
     5

--- a/tests/negative/typecheck/dyn_type_not_found.orng
+++ b/tests/negative/typecheck/dyn_type_not_found.orng
@@ -1,3 +1,7 @@
+// dyn_type_not_found.orng:6:30: error: use of undeclared identifier `Mystery_Trait`
+//     let x: &dyn Mystery_Trait = (4, 5)
+//                             ^
+// 
 fn main() -> Int {
     let x: &dyn Mystery_Trait = (4, 5)
     5

--- a/tests/negative/typecheck/dyn_type_not_trait.orng
+++ b/tests/negative/typecheck/dyn_type_not_trait.orng
@@ -1,3 +1,7 @@
+// dyn_type_not_trait.orng:7:18: error: expected trait type for dyn, got `y`
+//     let x: &dyn y = (4, 5)
+//                 ^
+// 
 fn main() -> Int {
     let y = 4
     let x: &dyn y = (4, 5)

--- a/tests/negative/typecheck/error.orng
+++ b/tests/negative/typecheck/error.orng
@@ -1,1 +1,5 @@
+// error.orng:5:29: error: expected a value of type `Int`, got a value of type `Type`
+// fn main() -> Int {Int ! Char}
+//                            ^
+// 
 fn main() -> Int {Int ! Char}

--- a/tests/negative/typecheck/false.orng
+++ b/tests/negative/typecheck/false.orng
@@ -1,1 +1,5 @@
+// false.orng:5:24: error: expected a value of type `Int`, got a value of type `Bool`
+// fn main() -> Int {false}
+//                       ^
+// 
 fn main() -> Int {false}

--- a/tests/negative/typecheck/float.orng
+++ b/tests/negative/typecheck/float.orng
@@ -1,1 +1,5 @@
+// float.orng:5:20: error: expected a value of type `Int`, got a value of type `Float`
+// fn main()->Int {0.4}
+//                   ^
+// 
 fn main()->Int {0.4}

--- a/tests/negative/typecheck/function.orng
+++ b/tests/negative/typecheck/function.orng
@@ -1,1 +1,5 @@
+// function.orng:5:22: error: expected a value of type `Int`, got a value of type `Type`
+// fn main()->Int {Int->Char}
+//                     ^
+// 
 fn main()->Int {Int->Char}

--- a/tests/negative/typecheck/identifier.orng
+++ b/tests/negative/typecheck/identifier.orng
@@ -1,3 +1,7 @@
+// identifier.orng:7:6: error: expected a value of type `Int`, got a value of type `Float`
+//     x
+//     ^
+// 
 fn main() -> Int {
     let x = 0.4
     x

--- a/tests/negative/typecheck/if_optional.orng
+++ b/tests/negative/typecheck/if_optional.orng
@@ -1,3 +1,7 @@
+// if_optional.orng:6:20: error: expected a value of type `Int`
+//     let x: Int = if true {1}
+//                   ^
+// 
 fn main() -> Int {
     let x: Int = if true {1}
     0

--- a/tests/negative/typecheck/immutable_dereference.orng
+++ b/tests/negative/typecheck/immutable_dereference.orng
@@ -1,3 +1,7 @@
+// immutable_dereference.orng:7:14: error: cannot modify non-mutable address
+//     let y = &x
+//             ^
+// 
 fn main() -> Int {
     let x = 0
     let y = &x

--- a/tests/negative/typecheck/immutable_index.orng
+++ b/tests/negative/typecheck/immutable_index.orng
@@ -1,3 +1,5 @@
+// error: cannot modify non-mutable address
+// 
 fn main() -> Int {
     let x: [4]Int = (1, 2, 3, 4)
     let y = []x

--- a/tests/negative/typecheck/immutable_misc.orng
+++ b/tests/negative/typecheck/immutable_misc.orng
@@ -1,3 +1,7 @@
+// immutable_misc.orng:6:6: error: the type `Int` is not indexable
+//     0[0] = 4
+//     ^
+// 
 fn main() -> Int {
     0[0] = 4
     0

--- a/tests/negative/typecheck/index_product.orng
+++ b/tests/negative/typecheck/index_product.orng
@@ -1,3 +1,7 @@
+// index_product.orng:7:6: error: array is not homotypical and index is not compile-time known
+//     x[f()]
+//     ^
+// 
 fn main() -> Int {
     let x: (a: Int, b: Char, c: Bool, d: Int)
     x[f()]

--- a/tests/negative/typecheck/index_slice.orng
+++ b/tests/negative/typecheck/index_slice.orng
@@ -1,3 +1,7 @@
+// index_slice.orng:8:7: error: expected a value of type `Int`, got a value of type `Char`
+//     y[1]
+//      ^
+// 
 fn main() -> Int {
     let x = ('1', '2', '3')
     let y = []x

--- a/tests/negative/typecheck/infer_fail.orng
+++ b/tests/negative/typecheck/infer_fail.orng
@@ -1,3 +1,7 @@
+// infer_fail.orng:6:17: error: cannot infer the sum type
+//     let x = .lol
+//                ^
+// 
 fn main() -> Int {
     let x = .lol
     0

--- a/tests/negative/typecheck/infer_non_sum.orng
+++ b/tests/negative/typecheck/infer_non_sum.orng
@@ -1,3 +1,7 @@
+// infer_non_sum.orng:6:22: error: expected sum type for sum value, got `Int`
+//     let x: Int = .lol
+//                     ^
+// 
 fn main() -> Int {
     let x: Int = .lol
     0

--- a/tests/negative/typecheck/infer_not_in.orng
+++ b/tests/negative/typecheck/infer_not_in.orng
@@ -1,3 +1,7 @@
+// infer_not_in.orng:6:28: error: member `d` not in sum: `(a: () | b: () | c: ())`
+//     let x: (a | b | c) = .d
+//                           ^
+// 
 fn main () -> Int {
     let x: (a | b | c) = .d
     0

--- a/tests/negative/typecheck/inject.orng
+++ b/tests/negative/typecheck/inject.orng
@@ -1,3 +1,7 @@
+// inject.orng:8:20: error: expected a value of type `Char`, got a value of type `Int`
+//     let x:T = S.b(3)
+//                   ^
+// 
 fn main() -> Int {
     const T = (a: Int | b: Int)
     const S = (a: Int | b: Char)

--- a/tests/negative/typecheck/inject_non_sum.orng
+++ b/tests/negative/typecheck/inject_non_sum.orng
@@ -1,3 +1,7 @@
+// inject_non_sum.orng:6:6: error: expected function type for call, got `Int`
+//     4(4)
+//     ^
+// 
 fn main() -> Int {
     4(4)
 }

--- a/tests/negative/typecheck/int.orng
+++ b/tests/negative/typecheck/int.orng
@@ -1,1 +1,5 @@
+// int.orng:5:20: error: expected a value of type `Float`, got a value of type `Int`
+// fn main()->Float {1}
+//                   ^
+// 
 fn main()->Float {1}

--- a/tests/negative/typecheck/int_assign.orng
+++ b/tests/negative/typecheck/int_assign.orng
@@ -1,3 +1,7 @@
+// int_assign.orng:6:6: error: not an l-value
+//     0 = 0
+//     ^
+// 
 fn main() -> Int {
     0 = 0
     0

--- a/tests/negative/typecheck/int_oob.orng
+++ b/tests/negative/typecheck/int_oob.orng
@@ -1,1 +1,5 @@
+// int_oob.orng:5:24: error: error: integer is out of bounds for type `Int8`; value=200
+// fn main() -> Int8 { 200 }
+//                       ^
+// 
 fn main() -> Int8 { 200 }

--- a/tests/negative/typecheck/mod.orng
+++ b/tests/negative/typecheck/mod.orng
@@ -1,1 +1,5 @@
+// mod.orng:5:21: error: expected a value of type `Char`, got a value of type `Int`
+// fn main()->Char {4 % 5}
+//                    ^
+// 
 fn main()->Char {4 % 5}

--- a/tests/negative/typecheck/mult.orng
+++ b/tests/negative/typecheck/mult.orng
@@ -1,1 +1,5 @@
+// mult.orng:5:19: error: expected a value of type `Char`, got a value of type `Int`
+// fn main()->Char {4 * 5}
+//                  ^
+// 
 fn main()->Char {4 * 5}

--- a/tests/negative/typecheck/negate.orng
+++ b/tests/negative/typecheck/negate.orng
@@ -1,1 +1,5 @@
+// negate.orng:5:20: error: expected a value of type `Char`, got a value of type `Int`
+// fn main()->Char {-3}
+//                   ^
+// 
 fn main()->Char {-3}

--- a/tests/negative/typecheck/no_default.orng
+++ b/tests/negative/typecheck/no_default.orng
@@ -1,3 +1,7 @@
+// no_default.orng:6:10: error: error: expected a compile-time constant type, got default
+//     const X: Type
+//         ^
+// 
 fn main() -> Int {
     const X: Type
     4

--- a/tests/negative/typecheck/not.orng
+++ b/tests/negative/typecheck/not.orng
@@ -1,1 +1,5 @@
+// not.orng:5:22: error: expected a value of type `Int`, got a value of type `Bool`
+// fn main() -> Int {not true}
+//                     ^
+// 
 fn main() -> Int {not true}

--- a/tests/negative/typecheck/optional.orng
+++ b/tests/negative/typecheck/optional.orng
@@ -1,1 +1,5 @@
+// optional.orng:5:23: error: expected a value of type `Int`, got a value of type `Type`
+// fn main() -> Int {?Int}
+//                      ^
+// 
 fn main() -> Int {?Int}

--- a/tests/negative/typecheck/or.orng
+++ b/tests/negative/typecheck/or.orng
@@ -1,1 +1,5 @@
+// or.orng:5:24: error: expected a value of type `Int`, got a value of type `Bool`
+// fn main()->Int {true or false}
+//                       ^
+// 
 fn main()->Int {true or false}

--- a/tests/negative/typecheck/orelse.orng
+++ b/tests/negative/typecheck/orelse.orng
@@ -1,3 +1,7 @@
+// orelse.orng:7:13: error: expected a value of type `Int`, got a value of type `Char`
+//     x orelse 4
+//            ^
+// 
 fn main() -> Int {
     let x: ?Char = .some('4')
     x orelse 4

--- a/tests/negative/typecheck/orelse_non_opt.orng
+++ b/tests/negative/typecheck/orelse_non_opt.orng
@@ -1,1 +1,5 @@
+// orelse_non_opt.orng:5:20: error: expected optional type for orelse, got `Int`
+// fn main() -> Int {4 orelse 5}
+//                   ^
+// 
 fn main() -> Int {4 orelse 5}

--- a/tests/negative/typecheck/product.orng
+++ b/tests/negative/typecheck/product.orng
@@ -1,1 +1,5 @@
+// product.orng:5:21: error: expected a value of type `Int`
+// fn main() -> Int{(1,2)}
+//                    ^
+// 
 fn main() -> Int{(1,2)}

--- a/tests/negative/typecheck/product_len.orng
+++ b/tests/negative/typecheck/product_len.orng
@@ -1,3 +1,7 @@
+// product_len.orng:6:33: error: product takes 3 fields, 2 values given
+//     let x: (Int, Int, Int) = (3, '3')
+//                                ^
+// 
 fn main() -> Int {
     let x: (Int, Int, Int) = (3, '3')
     x[0]

--- a/tests/negative/typecheck/return.orng
+++ b/tests/negative/typecheck/return.orng
@@ -1,1 +1,5 @@
+// return.orng:5:18: error: `return` is not inside a function
+// const x = {return}
+//                 ^
+// 
 const x = {return}

--- a/tests/negative/typecheck/select.orng
+++ b/tests/negative/typecheck/select.orng
@@ -1,3 +1,7 @@
+// select.orng:7:7: error: expected a value of type `Int`, got a value of type `Char`
+//     x.b
+//      ^
+// 
 fn main() -> Int {
     let x: (a: Int, b: Char) = (1, '2')
     x.b

--- a/tests/negative/typecheck/select_non.orng
+++ b/tests/negative/typecheck/select_non.orng
@@ -1,1 +1,5 @@
+// select_non.orng:5:32: error: left-hand-side of select is not selectable
+// fn main() -> Int {let x = 4; x.g}
+//                               ^
+// 
 fn main() -> Int {let x = 4; x.g}

--- a/tests/negative/typecheck/select_not_exist.orng
+++ b/tests/negative/typecheck/select_not_exist.orng
@@ -1,3 +1,7 @@
+// select_not_exist.orng:7:7: error: member `c` not in tuple: `[2]a: Int`
+//     x.c
+//      ^
+// 
 fn main() -> Int {
     let x: (a: Int, b: Int) = (3, 4)
     x.c

--- a/tests/negative/typecheck/sliceof.orng
+++ b/tests/negative/typecheck/sliceof.orng
@@ -1,3 +1,7 @@
+// sliceof.orng:7:21: error: expected a value of type `[]data: [*]Int`, got a value of type `[]data: [*]Char`
+//     let y: []Int = []x
+//                    ^
+// 
 fn main() -> Int {
     let x: [3]Char = ('a', 'b', 'c')
     let y: []Int = []x

--- a/tests/negative/typecheck/sliceof_arr.orng
+++ b/tests/negative/typecheck/sliceof_arr.orng
@@ -1,3 +1,7 @@
+// sliceof_arr.orng:7:24: error: expected a value of type `Type`, got a value of type `(Char, Char, Char)`
+//     let y: []Int = [3]x
+//                       ^
+// 
 fn main() -> Int {
     let x: [3]Char = ('a', 'b', 'c')
     let y: []Int = [3]x

--- a/tests/negative/typecheck/sliceof_non_array.orng
+++ b/tests/negative/typecheck/sliceof_non_array.orng
@@ -1,3 +1,7 @@
+// sliceof_non_array.orng:7:21: error: attempt to take slice-of something that is not an array
+//     let y: []Int = []x
+//                    ^
+// 
 fn main() -> Int {
     let x = 4
     let y: []Int = []x

--- a/tests/negative/typecheck/string.orng
+++ b/tests/negative/typecheck/string.orng
@@ -1,1 +1,5 @@
+// string.orng:5:22: error: expected a value of type `Int`, got a value of type `String`
+// fn main()->Int {"lol"}
+//                     ^
+// 
 fn main()->Int {"lol"}

--- a/tests/negative/typecheck/sub.orng
+++ b/tests/negative/typecheck/sub.orng
@@ -1,1 +1,5 @@
+// sub.orng:5:19: error: expected a value of type `Char`, got a value of type `Int`
+// fn main()->Char {4 - 5}
+//                  ^
+// 
 fn main()->Char {4 - 5}

--- a/tests/negative/typecheck/subslice_non_slice.orng
+++ b/tests/negative/typecheck/subslice_non_slice.orng
@@ -1,3 +1,7 @@
+// subslice_non_slice.orng:6:15: error: cannot take a sub-slice of something that is not a slice
+//     let x = 3[1..2]
+//              ^
+// 
 fn main() -> Int {
     let x = 3[1..2]
     4

--- a/tests/negative/typecheck/sum.orng
+++ b/tests/negative/typecheck/sum.orng
@@ -1,3 +1,7 @@
+// sum.orng:6:22: error: expected a value of type `Int`, got a value of type `Type`
+//     let x: Int = (x | y)
+//                     ^
+// 
 fn main() -> Int {
     let x: Int = (x | y)
     x

--- a/tests/negative/typecheck/sum_annot_repeat.orng
+++ b/tests/negative/typecheck/sum_annot_repeat.orng
@@ -1,3 +1,10 @@
+// sum_annot_repeat.orng:9:23: error: duplicate item `y`
+//     let x: (y:Int | y:Int | y:Int)
+//                      ^
+// sum_annot_repeat.orng:9:15: note: other definition of `y` here:
+//     let x: (y:Int | y:Int | y:Int)
+//              ^
+// 
 fn main() -> Int {
     let x: (y:Int | y:Int | y:Int)
     0

--- a/tests/negative/typecheck/sum_expr.orng
+++ b/tests/negative/typecheck/sum_expr.orng
@@ -1,3 +1,7 @@
+// sum_expr.orng:6:20: error: invalid sum expression, must be annotation or identifier
+//     let x: (y | z + 3)
+//                   ^
+// 
 fn main() -> Int {
     let x: (y | z + 3)
     4

--- a/tests/negative/typecheck/sum_repeat.orng
+++ b/tests/negative/typecheck/sum_repeat.orng
@@ -1,3 +1,10 @@
+// sum_repeat.orng:9:18: error: duplicate item `y`
+//     let x: (y | y | y)
+//                 ^
+// sum_repeat.orng:9:14: note: other definition of `y` here:
+//     let x: (y | y | y)
+//             ^
+// 
 fn main() -> Int {
     let x: (y | y | y)
     0

--- a/tests/negative/typecheck/true.orng
+++ b/tests/negative/typecheck/true.orng
@@ -1,1 +1,5 @@
+// true.orng:5:23: error: expected a value of type `Int`, got a value of type `Bool`
+// fn main() -> Int {true}
+//                      ^
+// 
 fn main() -> Int {true}

--- a/tests/negative/typecheck/try.orng
+++ b/tests/negative/typecheck/try.orng
@@ -1,3 +1,7 @@
+// try.orng:6:10: error: expected error type for try, got `Int`
+//     try 0
+//         ^
+// 
 fn main() -> Int {
     try 0
     0

--- a/tests/negative/typecheck/try_error.orng
+++ b/tests/negative/typecheck/try_error.orng
@@ -1,3 +1,7 @@
+// try_error.orng:10:8: error: expected a value of type `(ok: Int | err: Char)`, got a value of type `Int`
+//     try g()
+//       ^
+// 
 fn main() -> Int {
     f() catch 0
 }

--- a/tests/negative/typecheck/try_function.orng
+++ b/tests/negative/typecheck/try_function.orng
@@ -1,3 +1,7 @@
+// try_function.orng:6:8: error: enclosing function around try expression does not return an error
+//     try f()
+//       ^
+// 
 fn main() -> Int {
     try f()
 }

--- a/tests/negative/typecheck/try_function_incompat.orng
+++ b/tests/negative/typecheck/try_function_incompat.orng
@@ -1,3 +1,7 @@
+// try_function_incompat.orng:10:19: error: expected a value of type `(ok: Int | err: ())`, got a value of type `(ok: Int | err: Char)`
+//     let x = try g()
+//                  ^
+// 
 fn main() -> Int {
     f() catch 0
 }

--- a/tests/negative/typecheck/try_function_not_error.orng
+++ b/tests/negative/typecheck/try_function_not_error.orng
@@ -1,3 +1,7 @@
+// try_function_not_error.orng:6:8: error: enclosing function around try expression does not return an error
+//     try f()
+//       ^
+// 
 fn main() -> (ok: Int | err: Char) {
     try f()
     .ok(4)

--- a/tests/negative/typecheck/try_out_fn.orng
+++ b/tests/negative/typecheck/try_out_fn.orng
@@ -1,2 +1,6 @@
+// try_out_fn.orng:6:14: error: `try` is not inside a function
+// const x = try y
+//             ^
+// 
 const y: Char!Int = .ok(0)
 const x = try y

--- a/tests/negative/typecheck/try_sum_not_error.orng
+++ b/tests/negative/typecheck/try_sum_not_error.orng
@@ -1,3 +1,7 @@
+// try_sum_not_error.orng:6:11: error: expected error type for try, got `(ok: Int | err: Char)`
+//     try f()
+//          ^
+// 
 fn main() -> Int {
     try f()
 }

--- a/tests/negative/typecheck/typeclass_arithmetic.orng
+++ b/tests/negative/typecheck/typeclass_arithmetic.orng
@@ -1,3 +1,7 @@
+// typeclass_arithmetic.orng:6:6: error: expected a value of a(n) arithmetic type, got `Char`
+//     -'d'
+//     ^
+// 
 fn main() -> Char {
     -'d'
 }

--- a/tests/negative/typecheck/typeclass_eq.orng
+++ b/tests/negative/typecheck/typeclass_eq.orng
@@ -1,3 +1,10 @@
+// typeclass_eq.orng:9:30: error: error: expected a compile-time constant type, got unreachable
+//     let x: Void = unreachable
+//                             ^
+// typeclass_eq.orng:10:30: error: error: expected a compile-time constant type, got unreachable
+//     let y: Void = unreachable
+//                             ^
+// 
 fn main() -> Bool {
     let x: Void = unreachable
     let y: Void = unreachable

--- a/tests/negative/typecheck/typeclass_ord.orng
+++ b/tests/negative/typecheck/typeclass_ord.orng
@@ -1,3 +1,7 @@
+// typeclass_ord.orng:8:8: error: expected a value of a(n) orderable type, got `Bool`
+//     x < y
+//       ^
+// 
 fn main() -> Bool {
     let x = true
     let y = false

--- a/tests/negative/typecheck/union.orng
+++ b/tests/negative/typecheck/union.orng
@@ -1,1 +1,5 @@
+// union.orng:5:29: error: expected a value of type `Int`, got a value of type `Type`
+// fn main() -> Int {(x | y) || (z | a)}
+//                            ^
+// 
 fn main() -> Int {(x | y) || (z | a)}

--- a/tests/negative/typecheck/union_dup.orng
+++ b/tests/negative/typecheck/union_dup.orng
@@ -1,3 +1,7 @@
+// union_dup.orng:6:25: error: duplicate item `b`
+//     let x: (a | b) || (b | c) = .b
+//                        ^
+// 
 fn main() -> Int {
     let x: (a | b) || (b | c) = .b
     0

--- a/tests/negative/typecheck/union_non_sum.orng
+++ b/tests/negative/typecheck/union_non_sum.orng
@@ -1,3 +1,7 @@
+// union_non_sum.orng:6:18: error: expected sum type for union, got `Int`
+//     const A = Int || Float
+//                 ^
+// 
 fn main() -> Int {
     const A = Int || Float
     0

--- a/tests/negative/typecheck/union_right_non_sum.orng
+++ b/tests/negative/typecheck/union_right_non_sum.orng
@@ -1,3 +1,7 @@
+// union_right_non_sum.orng:6:29: error: expected sum type for union, got `Int`
+//     const A = (x | y) || Int
+//                            ^
+// 
 fn main() -> Int {
     const A = (x | y) || Int
     0

--- a/tests/negative/typecheck/unit.orng
+++ b/tests/negative/typecheck/unit.orng
@@ -1,2 +1,6 @@
+// unit.orng:5:20: error: expected a value of type `Int`, got a value of type `Type`
+// fn main() -> Int {()}
+//                   ^
+// 
 fn main() -> Int {()}
 fn lol() -> Int{()}

--- a/tests/negative/typecheck/unreachable_select.orng
+++ b/tests/negative/typecheck/unreachable_select.orng
@@ -1,3 +1,7 @@
+// unreachable_select.orng:6:17: error: left-hand-side of select is not selectable
+//     unreachable.x
+//                ^
+// 
 fn main() -> Int {
     unreachable.x
     4

--- a/tests/negative/typecheck/untagged_not_sum.orng
+++ b/tests/negative/typecheck/untagged_not_sum.orng
@@ -1,1 +1,5 @@
+// untagged_not_sum.orng:5:19: error: not a sum type
+// const x: @Untagged(Int)
+//                  ^
+// 
 const x: @Untagged(Int)

--- a/tests/negative/typecheck/void_assign.orng
+++ b/tests/negative/typecheck/void_assign.orng
@@ -1,3 +1,7 @@
+// void_assign.orng:6:20: error: error: expected a compile-time constant type, got int
+//     let x: Void = 0
+//                   ^
+// 
 fn main() -> Int {
     let x: Void = 0
     x

--- a/tests/test.py
+++ b/tests/test.py
@@ -10,14 +10,14 @@ commands:
         --test (-t)         - List of either files or directories to run tests on. Duplicates are allowed, and
                               only tested once.
         --no-coverage (-n)  - Do not run coverage after testing, even if all tests pass.
-        --count (-c)        - Recursively count the number of Orng integration test files in the directories 
+        --count (-c)        - Recursively count the number of Orng integration test files in the directories
                               given.
 
     negative    - Runs negative tests, runs kcov on integration tests if test pass.
         --test (-t)         - List of either files or directories to run tests on. Duplicates are allowed, and
                               only tested once.
         --no-coverage (-n)  - Do not run coverage after testing, even if all tests pass.
-        --count (-c)        - Recursively count the number of Orng integration test files in the directories 
+        --count (-c)        - Recursively count the number of Orng integration test files in the directories
                               given.
 
     fuzz        - Runs fuzz tests.
@@ -40,7 +40,9 @@ def main():
 
     shutil.rmtree("zig-cache", ignore_errors=True)
     shutil.rmtree("zig-out", ignore_errors=True)
-    res = subprocess.run(["zig", "build", "orng-test", "--release=safe", "-Doptimize=Debug"]).returncode
+    res = subprocess.run(
+        ["zig", "build", "orng-test", "--release=safe", "-Doptimize=Debug"]
+    ).returncode
     if res != 0:
         exit(1)
 
@@ -53,6 +55,8 @@ def main():
             all(args)
         case "modified":
             modified(args)
+        case "bless":
+            bless(args)
         case "fuzz":
             fuzz()
         # case "count":
@@ -64,22 +68,102 @@ def parse_args():
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     create = subparsers.add_parser("integration", help="run integration tests")
-    create.add_argument("-t", "--test", nargs="*", help="list of one or more files/directories of integration tests to run")
-    create.add_argument("-n", "--no-coverage", action='store_const', default=False, const=True, help="does not perform coverage after integration testing, even if tests pass")
-    create.add_argument("-c", "--count", nargs="*", help="recursively counts the number of integration test files in the directories specified")
+    create.add_argument(
+        "-t",
+        "--test",
+        nargs="*",
+        help="list of one or more files/directories of integration tests to run",
+    )
+    create.add_argument(
+        "-n",
+        "--no-coverage",
+        action="store_const",
+        default=False,
+        const=True,
+        help="does not perform coverage after integration testing, even if tests pass",
+    )
+    create.add_argument(
+        "-c",
+        "--count",
+        nargs="*",
+        help="recursively counts the number of integration test files in the directories specified",
+    )
 
     create = subparsers.add_parser("negative", help="run negative tests")
-    create.add_argument("-t", "--test", nargs="*", help="list of one or more files/directories of negative tests to run")
-    create.add_argument("-n", "--no-coverage", action='store_const', default=False, const=True, help="does not perform coverage after negative testing, even if tests pass")
-    create.add_argument("-c", "--count", nargs="*", help="recursively counts the number of negative test files in the directories specified")
+    create.add_argument(
+        "-t",
+        "--test",
+        nargs="*",
+        help="list of one or more files/directories of negative tests to run",
+    )
+    create.add_argument(
+        "-n",
+        "--no-coverage",
+        action="store_const",
+        default=False,
+        const=True,
+        help="does not perform coverage after negative testing, even if tests pass",
+    )
+    create.add_argument(
+        "-c",
+        "--count",
+        nargs="*",
+        help="recursively counts the number of negative test files in the directories specified",
+    )
 
-    create = subparsers.add_parser("all", help="run integration and negative tests, merge code coverage")
-    create.add_argument("-t", "--test", nargs="*", help="list of one or more files/directories of negative tests to run")
-    create.add_argument("-c", "--count", nargs="*", help="recursively counts the number of negative test files in the directories specified")
-    create.add_argument("-n", "--no-coverage", action='store_const', default=False, const=True, help="does not perform coverage after negative testing, even if tests pass")
+    create = subparsers.add_parser(
+        "all", help="run integration and negative tests, merge code coverage"
+    )
+    create.add_argument(
+        "-t",
+        "--test",
+        nargs="*",
+        help="list of one or more files/directories of negative tests to run",
+    )
+    create.add_argument(
+        "-c",
+        "--count",
+        nargs="*",
+        help="recursively counts the number of negative test files in the directories specified",
+    )
+    create.add_argument(
+        "-n",
+        "--no-coverage",
+        action="store_const",
+        default=False,
+        const=True,
+        help="does not perform coverage after negative testing, even if tests pass",
+    )
 
-    create = subparsers.add_parser("modified", help="run integration and negative tests, merge code coverage")
-    
+    create = subparsers.add_parser(
+        "modified", help="run integration and negative tests, merge code coverage"
+    )
+
+    create = subparsers.add_parser(
+        "bless",
+        help="run negative tests, accept whatever error messages are output and write them to the file",
+    )
+    create.add_argument(
+        "-t",
+        "--test",
+        nargs="*",
+        help="list of one or more files/directories of negative tests to run",
+    )
+    create.add_argument(
+        "-n",
+        "--no-coverage",
+        action="store_const",
+        default=False,
+        const=True,
+        help="does not perform coverage after negative testing, even if tests pass",
+    )
+    create.add_argument(
+        "-c",
+        "--count",
+        nargs="*",
+        help="recursively counts the number of negative test files in the directories specified",
+    )
+
     create = subparsers.add_parser("fuzz", help="create fuzz and run fuzz tests")
 
     return parser.parse_args()
@@ -91,7 +175,7 @@ def integration(args):
     if args.count:
         print("Number of integration test files: ", len(files))
         return
-    
+
     res = subprocess.run(["./zig-out/bin/orng-test", "integration"] + files).returncode
 
     if args.no_coverage:
@@ -101,7 +185,17 @@ def integration(args):
             print("test coverage not supported on Windows :(")
             return
         shutil.rmtree("kcov-out", ignore_errors=True)
-        subprocess.run(["kcov", "--include-path", SRC_DIR, "kcov-out", "./zig-out/bin/orng-test", "coverage"] + files)
+        subprocess.run(
+            [
+                "kcov",
+                "--include-path",
+                SRC_DIR,
+                "kcov-out",
+                "./zig-out/bin/orng-test",
+                "coverage",
+            ]
+            + files
+        )
         print("kcov ouput written to kcov-out/index.html")
     else:
         print("coverage not done due to failed tests")
@@ -115,31 +209,76 @@ def negative(args):
         return
 
     res = subprocess.run(["./zig-out/bin/orng-test", "negative"] + files).returncode
-    
+
     if args.no_coverage:
         return
     elif res == 0:
         if platform.system() == "Windows":
             print("test coverage not supported on Windows :(")
             return
-        subprocess.run(["kcov", "--include-path", SRC_DIR, "kcov-out", "./zig-out/bin/orng-test", "negative-coverage"] + files)
+        subprocess.run(
+            [
+                "kcov",
+                "--include-path",
+                SRC_DIR,
+                "kcov-out",
+                "./zig-out/bin/orng-test",
+                "negative-coverage",
+            ]
+            + files
+        )
         print("kcov ouput written to kcov-out/index.html")
     else:
         print("coverage not done due to failed tests")
 
 
+def bless(args):
+    files = collect_files(args, "tests/negative")
+
+    if args.count:
+        print("Number of negative test files: ", len(files))
+        return
+
+    res = subprocess.run(["./zig-out/bin/orng-test", "bless"] + files).returncode
+
+
 def all(args):
     files = collect_files(args, "tests/integration")
-    integration_res = subprocess.run(["./zig-out/bin/orng-test", "integration"] + files).returncode
+    integration_res = subprocess.run(
+        ["./zig-out/bin/orng-test", "integration"] + files
+    ).returncode
     if not args.no_coverage and platform.system() != "Windows":
-        subprocess.run(["kcov", "--clean", "--include-path", SRC_DIR, "kcov-out", "./zig-out/bin/orng-test", "coverage"] + files)
-        
+        subprocess.run(
+            [
+                "kcov",
+                "--clean",
+                "--include-path",
+                SRC_DIR,
+                "kcov-out",
+                "./zig-out/bin/orng-test",
+                "coverage",
+            ]
+            + files
+        )
+
     files = collect_files(args, "tests/negative")
     negative_res = 0
     if not args.no_coverage and platform.system() != "Windows":
-        subprocess.run(["kcov", "--include-path", SRC_DIR, "kcov-out", "./zig-out/bin/orng-test", "negative"] + files)
+        subprocess.run(
+            [
+                "kcov",
+                "--include-path",
+                SRC_DIR,
+                "kcov-out",
+                "./zig-out/bin/orng-test",
+                "negative",
+            ]
+            + files
+        )
     else:
-        negative_res = subprocess.run(["./zig-out/bin/orng-test", "negative"] + files).returncode
+        negative_res = subprocess.run(
+            ["./zig-out/bin/orng-test", "negative"] + files
+        ).returncode
 
     if negative_res != 0 or integration_res != 0:
         exit(1)
@@ -149,46 +288,99 @@ def modified(args):
     files = collect_modified_files(args, "tests/integration")
     integration_res = 0
     if len(files) > 0:
-        integration_res = subprocess.run(["./zig-out/bin/orng-test", "integration"] + files).returncode
+        integration_res = subprocess.run(
+            ["./zig-out/bin/orng-test", "integration"] + files
+        ).returncode
         if platform.system() != "Windows":
-            subprocess.run(["kcov", "--clean", "--include-path", SRC_DIR, "kcov-out", "./zig-out/bin/orng-test", "coverage"] + files)
+            subprocess.run(
+                [
+                    "kcov",
+                    "--clean",
+                    "--include-path",
+                    SRC_DIR,
+                    "kcov-out",
+                    "./zig-out/bin/orng-test",
+                    "coverage",
+                ]
+                + files
+            )
 
     files = collect_modified_files(args, "tests/negative")
     negative_res = 0
     if len(files) > 0:
         if platform.system() != "Windows":
-            subprocess.run(["kcov", "--include-path", SRC_DIR, "kcov-out", "./zig-out/bin/orng-test", "negative"] + files)
+            subprocess.run(
+                [
+                    "kcov",
+                    "--include-path",
+                    SRC_DIR,
+                    "kcov-out",
+                    "./zig-out/bin/orng-test",
+                    "negative",
+                ]
+                + files
+            )
         else:
-            negative_res = subprocess.run(["./zig-out/bin/orng-test", "negative"] + files).returncode
+            negative_res = subprocess.run(
+                ["./zig-out/bin/orng-test", "negative"] + files
+            ).returncode
 
     if negative_res != 0 or integration_res != 0:
         exit(1)
 
-    
+
 def fuzz():
     res = subprocess.run(["zig", "build", "orng"]).returncode
     if res != 0:
         return
     subprocess.run(["rm", "tests/fuzz/problems.txt"]).returncode
 
-    print("Running fuzz tests... inputs that cause compiler crashes will be placed in tests/fuzz/problems.txt")
+    print(
+        "Running fuzz tests... inputs that cause compiler crashes will be placed in tests/fuzz/problems.txt"
+    )
 
-    for i in range(0, 90_000_000): # 90,000,000 should be about 20 hours, enough for a 4HL fella
+    for i in range(
+        0, 90_000_000
+    ):  # 90,000,000 should be about 20 hours, enough for a 4HL fella
         now = datetime.datetime.now()
         print("{} {:,}".format(now, i * 10_000))
-        res = subprocess.run(["python3.11", "src/rdgen/main.py", "examples", "--input", "tests/fuzz/fuzz.ebnf", "--output", "tests/fuzz/fuzz.txt", "--quantity", "10000", "--limit", "3"]).returncode
+        res = subprocess.run(
+            [
+                "python3.11",
+                "src/rdgen/main.py",
+                "examples",
+                "--input",
+                "tests/fuzz/fuzz.ebnf",
+                "--output",
+                "tests/fuzz/fuzz.txt",
+                "--quantity",
+                "10000",
+                "--limit",
+                "3",
+            ]
+        ).returncode
         if res != 0:
             return
-        with open("tests/fuzz/fuzz.txt", "r") as f, open("tests/fuzz/problems.txt", "a") as problem_file:
+        with (
+            open("tests/fuzz/fuzz.txt", "r") as f,
+            open("tests/fuzz/problems.txt", "a") as problem_file,
+        ):
             for line in f:
-                if len(line) <3:
-                    continue # Skip opening and closing lines
-                eof_index = line.index("eof\"")
+                if len(line) < 3:
+                    continue  # Skip opening and closing lines
+                eof_index = line.index('eof"')
                 trimmed = line[3:eof_index]
                 with open("tests/fuzz/fuzz.orng", "w") as w:
                     w.write(trimmed)
                 try:
-                    res = subprocess.run(["./zig-out/bin/orng", "tests/fuzz/fuzz.orng", "_enable_fuzz_tokens"], timeout=2).returncode
+                    res = subprocess.run(
+                        [
+                            "./zig-out/bin/orng",
+                            "tests/fuzz/fuzz.orng",
+                            "_enable_fuzz_tokens",
+                        ],
+                        timeout=2,
+                    ).returncode
                 except subprocess.TimeoutExpired:
                     res = 1
                 if res != 0:
@@ -199,7 +391,9 @@ def fuzz():
 def collect_files(args, base):
     # Extract paths in the args.test list, if there are any
     # Prepend with base
-    if args.test and len(args.test) > 0 and args.test[0] != '.': # If the user enters `-t .`, treat that as a test of the whole directory
+    if (
+        args.test and len(args.test) > 0 and args.test[0] != "."
+    ):  # If the user enters `-t .`, treat that as a test of the whole directory
         full_path = [os.path.join(base, path) for path in args.test]
     elif args.count:
         full_path = [os.path.join(base, path) for path in args.count]
@@ -214,8 +408,15 @@ def collect_files(args, base):
 
 
 def collect_modified_files(args, base):
-    res = subprocess.run(["git", "diff", "--name-only", "--diff-filter=AM", "origin/main...HEAD"], capture_output=True).stdout.decode('utf-8').split('\n')
-    res = list(filter(lambda x: x.startswith(base) and x.endswith('.orng'), res))
+    res = (
+        subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=AM", "origin/main...HEAD"],
+            capture_output=True,
+        )
+        .stdout.decode("utf-8")
+        .split("\n")
+    )
+    res = list(filter(lambda x: x.startswith(base) and x.endswith(".orng"), res))
     return res
 
 
@@ -238,7 +439,6 @@ def collect_files_recursive(root_filename):
             files.append(root_and_filename)
     files.sort()
     return files
-
 
 
 if __name__ == "__main__":

--- a/tests/test.py
+++ b/tests/test.py
@@ -239,6 +239,8 @@ def bless(args):
         print("Number of negative test files: ", len(files))
         return
 
+    # run bless twice, once to get the error printed out, and the second to get the line number correct
+    res = subprocess.run(["./zig-out/bin/orng-test", "bless"] + files).returncode
     res = subprocess.run(["./zig-out/bin/orng-test", "bless"] + files).returncode
 
 

--- a/tests/test_bless.orng
+++ b/tests/test_bless.orng
@@ -1,16 +1,5 @@
-// non_exhaustive_sum.orng:4:10: error: match over sum type is not exhaustive
-//     match my_val {
-//         ^
-// non_exhaustive_sum.orng:2:34: note: term not handled: `d`
-//     const My_Sum = (a | b | c | d)
-//                                 ^
 // 
 fn main() -> Int {
-    const My_Sum = (a | b | c | d)
-    let my_val: My_Sum = .a
-    match my_val {
-        .a => 4
-        .b => 5
-        .c => 6
-    }
+    let x: Void = 0
+    x
 }

--- a/tests/test_bless.orng
+++ b/tests/test_bless.orng
@@ -1,5 +1,16 @@
+// non_exhaustive_sum.orng:4:10: error: match over sum type is not exhaustive
+//     match my_val {
+//         ^
+// non_exhaustive_sum.orng:2:34: note: term not handled: `d`
+//     const My_Sum = (a | b | c | d)
+//                                 ^
 // 
 fn main() -> Int {
-    let x: Void = 0
-    x
+    const My_Sum = (a | b | c | d)
+    let my_val: My_Sum = .a
+    match my_val {
+        .a => 4
+        .b => 5
+        .c => 6
+    }
 }

--- a/tests/test_bless.orng
+++ b/tests/test_bless.orng
@@ -1,0 +1,16 @@
+// non_exhaustive_sum.orng:4:10: error: match over sum type is not exhaustive
+//     match my_val {
+//         ^
+// non_exhaustive_sum.orng:2:34: note: term not handled: `d`
+//     const My_Sum = (a | b | c | d)
+//                                 ^
+// 
+fn main() -> Int {
+    const My_Sum = (a | b | c | d)
+    let my_val: My_Sum = .a
+    match my_val {
+        .a => 4
+        .b => 5
+        .c => 6
+    }
+}


### PR DESCRIPTION
This PR adds checks in negative tests to check that the error messages printed out match the expected error messages. Also adds a `bless` command to the test python script to take whatever error message the compiler gives and use it for the negative test.