### PR TITLE
Add `as` keyword

### DIFF
--- a/.github/workflows/build_example.yml
+++ b/.github/workflows/build_example.yml
@@ -41,7 +41,6 @@ jobs:
       run: |
         #!/bin/bash
         export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
-        export ORNG_BUILTIN_PATH="$GITHUB_WORKSPACE/src/hierarchy/builtin.orng"
         zig build orng
         cd examples
         ../zig-out/bin/orng build
@@ -52,7 +51,6 @@ jobs:
       run: |
         #!/bin/bash
         export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
-        export ORNG_BUILTIN_PATH="$GITHUB_WORKSPACE/src/hierarchy/builtin.orng"
         zig build orng
         cd examples
         ../zig-out/bin/orng build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,13 +59,13 @@ jobs:
     - name: Build project (Linux)
       run: |
         export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
-        export ORNG_BUILTIN_PATH="$GITHUB_WORKSPACE/src/hierarchy/builtin.orng"
         python tests/test.py all
         zig build orng
         cd examples
-        kcov --include-path "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/kcov-out" ../zig-out/bin/orng build
-        kcov --include-path "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/kcov-out" ../zig-out/bin/orng clean
-        kcov --include-path "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/kcov-out" ../zig-out/bin/orng test
+        kcov --include-path "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/kcov-out-tmp1" ../zig-out/bin/orng build
+        kcov --include-path "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/kcov-out-tmp2" ../zig-out/bin/orng clean
+        kcov --include-path "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/kcov-out-tmp3" ../zig-out/bin/orng test
+        kcov --merge "$GITHUB_WORKSPACE/kcov-out" "$GITHUB_WORKSPACE/kcov-out-tmp1" "$GITHUB_WORKSPACE/kcov-out-tmp2" "$GITHUB_WORKSPACE/kcov-out-tmp3"
         cd ..
 
     - name: Ensure Modified Lines in src/ Are Covered

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -58,12 +58,13 @@ jobs:
         export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
         python tests/test.py all --no-coverage
 
-    - name: Build project (Windows)
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
-        python tests/test.py all --no-coverage
+    # TODO: Once zig gets its act together and child process stdout actually works on Windows... smh
+    # - name: Build project (Windows)
+    #   if: runner.os == 'Windows'
+    #   shell: bash
+    #   run: |
+    #     export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
+    #     python tests/test.py all --no-coverage
 
     # Upload artifacts if build fails
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,7 +56,6 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
-        export ORNG_BUILTIN_PATH="$GITHUB_WORKSPACE/src/hierarchy/builtin.orng"
         python tests/test.py all --no-coverage
 
     - name: Build project (Windows)
@@ -64,7 +63,6 @@ jobs:
       shell: bash
       run: |
         export ORNG_STD_PATH="$GITHUB_WORKSPACE/std"
-        export ORNG_BUILTIN_PATH="$GITHUB_WORKSPACE/src/hierarchy/builtin.orng"
         python tests/test.py all --no-coverage
 
     # Upload artifacts if build fails

--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,7 @@ fn executable(b: *std.Build, optimize: std.builtin.OptimizeMode, target: std.Bui
             .target = target,
             .optimize = optimize,
         }),
+        .use_llvm = true,
     });
     exe.want_lto = false;
     const install_cmd = b.addInstallArtifact(exe, .{});

--- a/src/ast/walker.zig
+++ b/src/ast/walker.zig
@@ -114,6 +114,11 @@ pub fn walk_ast(maybe_ast: ?*ast_.AST, context: anytype) Error!void {
         .cinclude,
         => try walk_ast(ast.expr(), new_context),
 
+        .as => {
+            try walk_ast(ast.expr(), new_context);
+            try walk_type(ast.type(), new_context);
+        },
+
         .assign,
         .@"or",
         .@"and",

--- a/src/codegen/source_emitter.zig
+++ b/src/codegen/source_emitter.zig
@@ -408,6 +408,14 @@ fn output_instruction_post_check(self: *Self, instr: *Instruction) CodeGen_Error
             try self.output_rvalue(instr.src1.?, instr.kind.precedence());
             try self.writer.print(".tag;\n", .{});
         },
+        .cast => {
+            try self.output_var_assign(instr.dest.?);
+            try self.writer.print("(", .{});
+            try self.emitter.output_type(instr.dest.?.get_expanded_type());
+            try self.writer.print(")", .{});
+            try self.output_rvalue(instr.src1.?, instr.kind.precedence());
+            try self.writer.print(";\n", .{});
+        },
         .call => {
             // TODO: De-duplicate 2
             try self.output_call_prefix(instr);

--- a/src/ir/lower.zig
+++ b/src/ir/lower.zig
@@ -163,6 +163,13 @@ fn lower_AST_inner(
         .false => return self.lval_from_int(0, self.ctx.typecheck.typeof(ast), ast.token().span),
         // Unary operators
         .not, .negate, .addr_of, .bit_not => return try self.unop(ast, labels),
+        .as => {
+            const expr = try self.lower_AST(ast.expr(), labels) orelse return null;
+            const expanded_type = self.ctx.typecheck.typeof(ast).expand_identifier();
+            const temp = self.create_temp_lvalue(expanded_type);
+            self.instructions.append(Instruction.init(.cast, temp, expr, null, ast.token().span, self.ctx.allocator())) catch unreachable;
+            return temp;
+        },
         .dereference => {
             const expr = try self.lower_AST(ast.expr(), labels) orelse return null;
             const expanded_type = self.ctx.typecheck.typeof(ast).expand_identifier();

--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -18,6 +18,7 @@ pub const Kind = enum(u32) {
     multi_line_string,
 
     // Keywords
+    as,
     @"and",
     @"break",
     @"catch",
@@ -141,6 +142,7 @@ pub const Kind = enum(u32) {
             .comment => "<a comment>",
             .newline => "<a newline>",
 
+            .as => "as",
             .@"and" => "and",
             .@"break" => "break",
             .@"catch" => "catch",

--- a/src/parser/parse.zig
+++ b/src/parser/parse.zig
@@ -737,17 +737,26 @@ fn int_expr(self: *Self) Parser_Error_Enum!*ast_.AST {
 }
 
 fn term_expr(self: *Self) Parser_Error_Enum!*ast_.AST {
-    var exp = try self.prefix_expr();
+    var exp = try self.as_expr();
     while (true) {
         if (self.accept(.star)) |token| {
-            exp = ast_.AST.create_mult(token, exp, try self.prefix_expr(), self.allocator);
+            exp = ast_.AST.create_mult(token, exp, try self.as_expr(), self.allocator);
         } else if (self.accept(.slash)) |token| {
-            exp = ast_.AST.create_div(token, exp, try self.prefix_expr(), self.allocator);
+            exp = ast_.AST.create_div(token, exp, try self.as_expr(), self.allocator);
         } else if (self.accept(.percent)) |token| {
-            exp = ast_.AST.create_mod(token, exp, try self.prefix_expr(), self.allocator);
+            exp = ast_.AST.create_mod(token, exp, try self.as_expr(), self.allocator);
         } else {
             return exp;
         }
+    }
+}
+
+fn as_expr(self: *Self) Parser_Error_Enum!*ast_.AST {
+    const exp = try self.prefix_expr();
+    if (self.accept(.as)) |token| {
+        return ast_.AST.create_as(token, exp, try self.type_expr(), self.allocator);
+    } else {
+        return exp;
     }
 }
 

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -536,6 +536,11 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST) Val
             }
             return Type_AST.create_array_of(ast.token(), first_type, ast_.AST.create_int(ast.token(), ast.children().items.len, self.ctx.allocator()), self.ctx.allocator());
         },
+        .as => {
+            const child_type = self.typecheck_AST(ast.expr(), null) catch return error.CompileError;
+            _ = child_type; // TODO check convertible
+            return ast.type();
+        },
         .addr_of => {
             // FIXME: High cyclo
             if (expected == null) {

--- a/src/semantic/typecheck.zig
+++ b/src/semantic/typecheck.zig
@@ -538,7 +538,10 @@ fn typecheck_AST_internal(self: *Self, ast: *ast_.AST, expected: ?*Type_AST) Val
         },
         .as => {
             const child_type = self.typecheck_AST(ast.expr(), null) catch return error.CompileError;
-            _ = child_type; // TODO check convertible
+            if (!child_type.convertible_to(ast.type())) {
+                self.ctx.errors.add_error(errs_.Error{ .non_convertible = .{ .span = ast.token().span, .from = child_type, .to = ast.type() } });
+                return error.CompileError;
+            }
             return ast.type();
         },
         .addr_of => {

--- a/src/types/type.zig
+++ b/src/types/type.zig
@@ -1003,6 +1003,77 @@ pub const Type_AST = union(enum) {
         }
     }
 
+    /// Returns whether the term A is convertible to B
+    pub fn convertible_to(A: *Type_AST, B: *Type_AST) bool {
+        const A_expanded = A.expand_identifier();
+        const B_expanded = B.expand_identifier();
+
+        if (@intFromEnum(A_expanded.*) != @intFromEnum(B_expanded.*)) {
+            return false;
+        }
+
+        return switch (A_expanded.*) {
+            .addr_of => A_expanded.addr_of.multiptr and B_expanded.addr_of.multiptr,
+            else => false,
+        };
+    }
+
+    /// Checks whether two AST types would generate to the same C type.
+    pub fn c_types_match(self: *Type_AST, other: *Type_AST) bool {
+        // FIXME: High Cyclo
+        if (self.* == .annotation) {
+            return c_types_match(self.child(), other);
+        } else if (other.* == .annotation) {
+            return c_types_match(self, other.child());
+        }
+        if (self.* == .access) {
+            return c_types_match(self.symbol().?.init_typedef().?, other);
+        } else if (other.* == .access) {
+            return c_types_match(self, other.symbol().?.init_typedef().?);
+        }
+        if (other.* == .anyptr_type and self.* == .addr_of) {
+            return true;
+        }
+        // std.debug.assert(self.common().validation_state == .valid);
+        // std.debug.assert(other.common().validation_state == .valid);
+
+        if (@intFromEnum(self.*) != @intFromEnum(other.*)) {
+            return false;
+        }
+
+        switch (self.*) {
+            .identifier => return std.mem.eql(u8, self.token().data, other.token().data),
+            .addr_of => return c_types_match(self.child(), other.child()),
+            .unit_type => return other.* == .unit_type,
+            .anyptr_type => return other.* == .anyptr_type,
+            .dyn_type => return self.child().symbol() == other.child().symbol(),
+            .struct_type, .tuple_type, .enum_type, .untagged_sum_type => {
+                if (other.children().items.len != self.children().items.len) {
+                    return false;
+                }
+                var retval = true;
+                for (self.children().items, other.children().items) |term, other_term| {
+                    retval = retval and term.c_types_match(other_term);
+                }
+                return retval;
+            },
+            .generic_apply => {
+                if (other.children().items.len != self.children().items.len) {
+                    return false;
+                }
+                var retval = self.lhs().symbol() == other.lhs().symbol();
+                for (self.children().items, other.children().items) |term, B_term| {
+                    retval = retval and term.c_types_match(B_term);
+                }
+                return retval;
+            },
+            .function => return self.lhs().c_types_match(other.lhs()) and self.rhs().c_types_match(other.rhs()),
+            .array_of => return self.child().c_types_match(other.child()),
+            // .slice_of => return self.child().c_types_match(other.child()),
+            else => std.debug.panic("compiler error: c_types_match(): unimplemented for {s}", .{@tagName(self.*)}),
+        }
+    }
+
     pub fn clone(self: *Type_AST, substs: *unification_.Substitutions, allocator: std.mem.Allocator) *Type_AST {
         switch (self.*) {
             .anyptr_type, .dyn_type, .unit_type => return self,
@@ -1186,62 +1257,6 @@ pub const Type_AST = union(enum) {
             return false;
         }
         return prelude_.info_from_ast(expanded).?.is_bits();
-    }
-
-    /// Checks whether two AST types would generate to the same C type.
-    pub fn c_types_match(self: *Type_AST, other: *Type_AST) bool {
-        // FIXME: High Cyclo
-        if (self.* == .annotation) {
-            return c_types_match(self.child(), other);
-        } else if (other.* == .annotation) {
-            return c_types_match(self, other.child());
-        }
-        if (self.* == .access) {
-            return c_types_match(self.symbol().?.init_typedef().?, other);
-        } else if (other.* == .access) {
-            return c_types_match(self, other.symbol().?.init_typedef().?);
-        }
-        if (other.* == .anyptr_type and self.* == .addr_of) {
-            return true;
-        }
-        // std.debug.assert(self.common().validation_state == .valid);
-        // std.debug.assert(other.common().validation_state == .valid);
-
-        if (@intFromEnum(self.*) != @intFromEnum(other.*)) {
-            return false;
-        }
-
-        switch (self.*) {
-            .identifier => return std.mem.eql(u8, self.token().data, other.token().data),
-            .addr_of => return c_types_match(self.child(), other.child()),
-            .unit_type => return other.* == .unit_type,
-            .anyptr_type => return other.* == .anyptr_type,
-            .dyn_type => return self.child().symbol() == other.child().symbol(),
-            .struct_type, .tuple_type, .enum_type, .untagged_sum_type => {
-                if (other.children().items.len != self.children().items.len) {
-                    return false;
-                }
-                var retval = true;
-                for (self.children().items, other.children().items) |term, other_term| {
-                    retval = retval and term.c_types_match(other_term);
-                }
-                return retval;
-            },
-            .generic_apply => {
-                if (other.children().items.len != self.children().items.len) {
-                    return false;
-                }
-                var retval = self.lhs().symbol() == other.lhs().symbol();
-                for (self.children().items, other.children().items) |term, B_term| {
-                    retval = retval and term.c_types_match(B_term);
-                }
-                return retval;
-            },
-            .function => return self.lhs().c_types_match(other.lhs()) and self.rhs().c_types_match(other.rhs()),
-            .array_of => return self.child().c_types_match(other.child()),
-            // .slice_of => return self.child().c_types_match(other.child()),
-            else => std.debug.panic("compiler error: c_types_match(): unimplemented for {s}", .{@tagName(self.*)}),
-        }
     }
 
     pub fn is_c_void_type(self: *Type_AST) bool {

--- a/src/util/errors.zig
+++ b/src/util/errors.zig
@@ -161,6 +161,11 @@ pub const Error = union(enum) {
         expected: *Type_AST,
         got: *Type_AST,
     },
+    non_convertible: struct {
+        span: Span,
+        from: *Type_AST,
+        to: *Type_AST,
+    },
     unexpected_type_type: struct {
         span: Span,
         expected: ?*Type_AST,
@@ -288,6 +293,7 @@ pub const Error = union(enum) {
             .trait_virtual_refers_to_self => return self.trait_virtual_refers_to_self.span,
 
             .unexpected_type => return self.unexpected_type.span,
+            .non_convertible => return self.non_convertible.span,
             .unexpected_type_type => return self.unexpected_type_type.span,
             .expected_builtin_typeclass => return self.expected_builtin_typeclass.span,
             .duplicate => return self.duplicate.span,
@@ -465,6 +471,9 @@ pub const Error = union(enum) {
                     err.unexpected_type.got.print_type(writer) catch unreachable;
                 }
                 writer.print("`\n", .{}) catch unreachable;
+            },
+            .non_convertible => {
+                writer.print("cannot cast type `{f}` to type `{f}`\n", .{ err.non_convertible.from, err.non_convertible.to }) catch unreachable;
             },
             .unexpected_type_type => {
                 if (err.unexpected_type_type.expected) |expected| {

--- a/tests/integration/expressions/as.orng
+++ b/tests/integration/expressions/as.orng
@@ -1,0 +1,7 @@
+// -6510615555426900571
+fn main() -> Int {
+    let x: String = "\xA5\xA5\xA5\xA5\xA5\xA5\xA5\xA5"
+    let x_ptr: [*]Byte = x.data
+    let int_ptr = x_ptr as [*]Int
+    int_ptr[0]
+}

--- a/tests/negative/typecheck/non_convertible.orng
+++ b/tests/negative/typecheck/non_convertible.orng
@@ -1,0 +1,8 @@
+// non_convertible.orng:7:9: error: cannot cast type `String` to type `Int`
+//     x as Int
+//        ^
+// 
+fn main() -> Int {
+    let x: String = "5"
+    x as Int
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -47,14 +47,7 @@ def main():
     if res != 0:
         exit(1)
     res = subprocess.run(
-        [
-            "zig",
-            "build",
-            "orng-test",
-            "--release=safe",
-            "-Doptimize=Debug",
-            "-freference-trace=3",
-        ]
+        ["zig", "build", "orng-test", "--release=safe", "-Doptimize=Debug"]
     ).returncode
     if res != 0:
         exit(1)


### PR DESCRIPTION
This PR adds the `as` keyword, which for now only allows for converting between multi-ptrs.